### PR TITLE
chore: make serialport an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "debug": "^3.1.0",
     "int64-buffer": "^0.1.10",
     "lodash": "^4.17.4",
-    "serialport": "^6.0.0",
     "split": "^1.0.1"
   },
   "devDependencies": {
@@ -53,6 +52,7 @@
     "mocha": "^5.0.0"
   },
   "optionalDependencies": {
+    "serialport": "^6.0.0",
     "socketcan": "^2.2.2"
   },
   "repository": {


### PR DESCRIPTION
With this change canboatjs install will not fail
for missing serialport prebuilt binary/capability
to compile it from the source. This way it is in
line with socketcan.