### PR TITLE
fix: Handle offset values

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -434,6 +434,9 @@ function readField(options, runPostProcessor, pgn, field, bs) {
         value = postProcessor(field, value)
       }
     } else {
+      if ( field.Offset ) {
+        value += field.Offset
+      }
       if ( field.Resolution ) {
         var resolution = field.Resolution
 
@@ -472,12 +475,6 @@ function readField(options, runPostProcessor, pgn, field, bs) {
       } else if (field.Units === "Ah") {
         value *= 3600.0; // 1 Ah = 3600 C.
       }
-
-      /*
-      if ( field.Offset ) {
-        value += field.Offset
-      }
-      */
     }
   }
   return value

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -169,11 +169,9 @@ function writeField(bs, field, data, value, bitLength) {
       } else if (field.Units === "Ah") {
         value /= 3600.0; // 1 Ah = 3600 C.
       }
-      /*
       if ( field.Offset ) {
         value -= field.Offset
       }
-      */
 
       if (bitLength == 0) {
         writeVariableLengthField(bs, data, field, value)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@canboat/pgns": "git+https://github.com/oceanplanetenergy/canboat-pgns.git",
+    "@canboat/pgns": "1.0.x",
     "bit-buffer": "0.2.3",
     "debug": "^3.1.0",
     "int64-buffer": "^0.1.10",

--- a/test/pgns/65026.js
+++ b/test/pgns/65026.js
@@ -1,4 +1,25 @@
 module.exports = [{
-  "expected": {"timestamp":"2016-02-28T19:57:02.826Z","prio":3,"src":196,"dst":255,"pgn":65026,"description":"Generator Phase A AC Power","fields":{"Real Power":38466,"Apparent Power":30517}},
-  "input": "2016-02-28T19:57:02.826Z,3,65026,196,255,8,42,96,35,77,ff,ff,ff,ff"
-}]
+  "expected": {
+    "timestamp":"2016-02-28T19:57:02.826Z",
+    "prio":3,"src":196,"dst":255,"pgn":65026,
+    "description":"Generator Phase A AC Power",
+    "fields":{"Real Power":578,"Apparent Power":643}},
+  "input": "2016-02-28T19:57:02.826Z,3,65026,196,255,8,42,96,35,77,83,96,35,77"
+},
+{
+  "expected": {
+    "timestamp":"2016-02-28T19:57:02.826Z",
+    "prio":3,"src":194,"dst":255,"pgn":65026,
+    "description":"Generator Phase A AC Power",
+    "fields":{"Real Power":0,"Apparent Power":0}},
+  "input": "2016-02-28T19:57:02.826Z,3,65026,194,255,8,00,94,35,77,00,94,35,77"
+},
+{
+  "expected": {
+    "timestamp":"2016-02-28T19:57:15.807Z",
+    "prio":3,"src":195,"dst":255,"pgn":65026,
+    "description":"Generator Phase A AC Power",
+    "fields":{"Real Power":3981,"Apparent Power":4022}},
+  "input": "2016-02-28T19:57:15.807Z,3,65026,195,255,8,8d,a3,35,77,b6,a3,35,77"
+}
+]

--- a/test/test.js
+++ b/test/test.js
@@ -20,21 +20,25 @@ describe('from pgn test data converts', function () {
     var dataList = testData[key]
 
     it(`from pgn ${key} (${dataList[0].expected.description}) converts`, function (done) {
-
+      let testsRemaining = dataList.length
+      function success() {
+        testsRemaining -= 1
+        if (!testsRemaining) done()
+      }
       dataList.forEach(data => {
         if ( data.disabled ) {
-          done()
+          success()
           return
         }
-        
+
         var fromPgn = new FromPgn({format: 1})
-        
+
         fromPgn.on('error', (pgn, error) => {
           console.error(`Error parsing ${pgn.pgn} ${error}`)
           console.error(error.stack)
           done(error)
         })
-        
+
         fromPgn.on('warning', (pgn, warning) => {
           done(new Error(`${pgn.pgn} ${warning}`))
         })
@@ -42,14 +46,14 @@ describe('from pgn test data converts', function () {
         fromPgn.on('pgn', (pgn) => {
           try {
             //console.log(JSON.stringify(data.expected))
-            
+
             pgn.should.jsonEqual(data.expected)
-            done()
+            success()
           } catch ( e ) {
           done(e)
           }
         })
-        
+
         fromPgn.parseString(data.input)
       })
     })
@@ -64,10 +68,14 @@ describe('to pgn test data converts', function () {
     var dataList = testData[key]
 
     it(`to pgn ${key} (${dataList[0].expected.description}) converts`, function (done) {
-
+      let testsRemaining = dataList.length
+      function success() {
+        testsRemaining -= 1
+        if (!testsRemaining) done()
+      }
       dataList.forEach(test => {
         if ( test.disabled ) {
-          done()
+          success()
           return
         }
 
@@ -80,10 +88,8 @@ describe('to pgn test data converts', function () {
         result[2].should.equal(expected[2])
 
         result.slice(5).should.deep.equal(expected.slice(5))
-        done()
+        success()
       })
     })
   })
 })
-
-


### PR DESCRIPTION
I noticed a issue with the info related to PGN 65026. https://github.com/canboat/canboat/pull/145

The test file in this project was modified from the [original feed](https://github.com/canboat/canboat/blob/master/samples/dirona-actisense-serial.raw).

original: `2016-02-28T19:57:02.826Z,3,65026,196,255,8,42,96,35,77,83,96,35,77`
65026.js: `2016-02-28T19:57:02.826Z,3,65026,196,255,8,42,96,35,77,ff,ff,ff,ff`

I updated the test to contain the correct hex values and included two more examples. I had to adjust the test script to handle multiple tests for a single PGN.

Lastly I uncommented the offset handling code to get the correct values. Was there a reason the offset code was commented out? In this very specific example it works as expected.