### PR TITLE
refactor: Yacht Devices RAW format code cleanup. #42

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -268,7 +268,7 @@ class Parser extends EventEmitter {
     if ( parts.length != 11 ) return undefined
     const [ time, direction, canId, ...data ] = parts
     const pgn = getPGNFromCanId(parseInt(canId, 16))
-    pgn.timestamp = parseDate('16:29:27.986', 'HH:mm:ss.SSS', new Date())
+    pgn.timestamp = parseDate(time, 'HH:mm:ss.SSS', new Date())
     const bs = new BitStream(Buffer.from(data.join(''), 'hex'))
     if ( this._parse(pgn, bs, 8) ) {
       debug('parsed pgn %j', pgn)

--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -23,6 +23,7 @@ const BitStream = require('bit-buffer').BitStream
 const BitView = require('bit-buffer').BitView
 const Int64LE = require('int64-buffer').Int64LE
 const Uint64LE = require('int64-buffer').Uint64LE
+const { parse: parseDate } = require('date-fns')
 const { getPGNFromCanId, getManufacturerName, getIndustryName } = require('./utilities')
 
 var fieldTypeReaders = {}
@@ -263,39 +264,13 @@ class Parser extends EventEmitter {
 
   //Yacht Devices NMEA2000 Wifi gateway
   parseYDWG02(pgn_data) {
-    var split = pgn_data.split(' ')
-
-    if ( split.length != 11 )
-    {
-      return
-    }
-
-    var pgn
-    var buffer
-    var len = 8
-
-    pgn = getPGNFromCanId(parseInt(split[2], 16))
-    //pgn.timestamp = new Date().toISOString()
-    let today = new Date()
-    let timeParts = split[0].split(':')
-    today.setHours(parseInt(timeParts[0]))
-    today.setMinutes(parseInt(timeParts[1]))
-    let sms = timeParts[2].split('.')
-    today.setSeconds(parseInt(sms[0]))
-    today.setMilliseconds(parseInt(sms[1]))
-
-    pgn.timestamp = today.toISOString()
-
-    let array = new Int16Array(len)
-    for ( var i = 0, j = 3; i < len; i++, j++ ) {
-      array[i] = parseInt(split[j], 16)
-    }
-    buffer = new Buffer(array)
-
-    var bv = new BitView(buffer);
-    var bs = new BitStream(bv)
-    
-    if ( this._parse(pgn, bs, len) ) {
+    const parts = pgn_data.split(' ')
+    if ( parts.length != 11 ) return undefined
+    const [ time, direction, canId, ...data ] = parts
+    const pgn = getPGNFromCanId(parseInt(canId, 16))
+    pgn.timestamp = parseDate('16:29:27.986', 'HH:mm:ss.SSS', new Date())
+    var bs = new BitStream(Buffer.from(data.join(''), 'hex'))
+    if ( this._parse(pgn, bs, 8) ) {
       debug('parsed pgn %j', pgn)
     }
   }

--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -269,7 +269,7 @@ class Parser extends EventEmitter {
     const [ time, direction, canId, ...data ] = parts
     const pgn = getPGNFromCanId(parseInt(canId, 16))
     pgn.timestamp = parseDate('16:29:27.986', 'HH:mm:ss.SSS', new Date())
-    var bs = new BitStream(Buffer.from(data.join(''), 'hex'))
+    const bs = new BitStream(Buffer.from(data.join(''), 'hex'))
     if ( this._parse(pgn, bs, 8) ) {
       debug('parsed pgn %j', pgn)
     }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@canboat/pgns": "1.0.x",
     "bit-buffer": "0.2.3",
+    "date-fns": "^1.30.1",
     "debug": "^3.1.0",
     "int64-buffer": "^0.1.10",
     "lodash": "^4.17.4",

--- a/test/ydwg02.js
+++ b/test/ydwg02.js
@@ -5,7 +5,7 @@ chai.use(require('chai-json-equal'));
 
 const { FromPgn } = require('../index')
 
-describe('from pcdin data converts', function () {
+describe('Convert Yacht Devices RAW format data', function () {
 
   var tests = [
     {
@@ -59,29 +59,29 @@ describe('from pcdin data converts', function () {
       }
     }
   ]
-  
+
   tests.forEach(test => {
     it(`from ${test.expected.pgn} converts`, function (done) {
-      
+
       var fromPgn = new FromPgn()
-    
+
       fromPgn.on('error', (pgn, error) => {
         console.error(`Error parsing ${pgn.pgn} ${error}`)
         console.error(error.stack)
         done(error)
       })
-      
+
       fromPgn.on('warning', (pgn, warning) => {
         done(new Error(`${pgn.pgn} ${warning}`))
       })
-      
+
       fromPgn.on('pgn', (pgn) => {
         try {
           //console.log(JSON.stringify(pgn))
-          
+
           let timestamp = pgn.timestamp
           delete pgn.timestamp
-          
+
           pgn.should.jsonEqual(test.expected)
           done()
         } catch ( e ) {


### PR DESCRIPTION
## `parseYDWG02` cleanup
* Used array [Destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) to assign variable names to array items.
* Added `date-fns` package to parse time string in one line. It's much smaller than `moment`.
* Created buffer directly from hex encoded string instead of `Int16Array` -> `Buffer` -> `BitView`
* Removed `len` variable and used `8` within `this._parse` since it's needed once.
* Renamed description in test and removed extra whitespace.

I think the only controversial change is using the `dane-fns` package. It's really small and v2 is [smaller still](https://blog.date-fns.org/post/we-cut-date-fns-v2-minimal-build-size-down-to-300-bytes-and-now-its-the-smallest-date-library-18f2nvh2z0yal). It works with native `Date` and doesn't have any specific class of its own. Just a collection of functions to make working with dates easier.

It might be better to call this `parseYdRaw` or similar since it's not specific to a single device and there are other manufacturers considering using the same format in other products.