### PR TITLE
fix: YDWG date parse error

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -280,7 +280,7 @@ class Parser extends EventEmitter {
     if ( parts.length != 11 ) return undefined
     const [ time, direction, canId, ...data ] = parts
     const pgn = getPGNFromCanId(parseInt(canId, 16))
-    pgn.timestamp = parseDate(time, 'HH:mm:ss.SSS', new Date()).toString()
+    pgn.timestamp = parseDate(time, 'HH:mm:ss.SSS', new Date()).toISOString()
     const bs = new BitStream(Buffer.from(data.join(''), 'hex'))
     if ( this._parse(pgn, bs, 8) ) {
       debug('parsed pgn %j', pgn)

--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -280,7 +280,7 @@ class Parser extends EventEmitter {
     if ( parts.length != 11 ) return undefined
     const [ time, direction, canId, ...data ] = parts
     const pgn = getPGNFromCanId(parseInt(canId, 16))
-    pgn.timestamp = parseDate(time, 'HH:mm:ss.SSS', new Date())
+    pgn.timestamp = parseDate(time, 'HH:mm:ss.SSS', new Date()).toString()
     const bs = new BitStream(Buffer.from(data.join(''), 'hex'))
     if ( this._parse(pgn, bs, 8) ) {
       debug('parsed pgn %j', pgn)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@canboat/pgns": "1.0.x",
     "bit-buffer": "0.2.3",
-    "date-fns": "^1.30.1",
+    "date-fns": "2.0.0-alpha.27",
     "debug": "^3.1.0",
     "int64-buffer": "^0.1.10",
     "lodash": "^4.17.4",


### PR DESCRIPTION
parseDate function with the arguments list corresponding to a new v2.0.0 date-fns version, while dependencies section of a package.json requires an old v1.30.1 version
updated the package dependencies and updated the ydwg parse to use toISOString

Closes #46