### PR TITLE
feature: add the ability for to ouput to the YDWG-02

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,13 @@
 
 /**
  * Copyright 2016/2017 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ module.exports = {
   toActisenseSerialFormat: require('./lib/toPgn').toActisenseSerialFormat,
   pgnToActisenseSerialFormat: require('./lib/toPgn').pgnToActisenseSerialFormat,
   pgnToiKonvertSerialFormat: require('./lib/toPgn').pgnToiKonvertSerialFormat,
+  pgnToYdwgRawFormat: require('./lib/toPgn').pgnToYdwgRawFormat,
   canbus: require('./lib/canbus'),
   iKonvert: require('./lib/ikonvert'),
   Ydwg02: require('./lib/ydwg02')

--- a/lib/canbus.js
+++ b/lib/canbus.js
@@ -24,7 +24,7 @@ const Parser = require('./fromPgn').Parser
 const _ = require('lodash')
 const CanDevice = require('./candevice')
 const spawn = require('child_process').spawn
-const { getPGNFromCanId, getCanIdFromPGN, actisenseSerialToBuffer } = require('./utilities')
+const { getPlainPGNs, getPGNFromCanId, getCanIdFromPGN, actisenseSerialToBuffer } = require('./utilities')
 
 const MSG_BUF_SIZE  			= 2000
 const CANDUMP_DATA_INC_3		= 3
@@ -227,36 +227,6 @@ CanbusStream.prototype.sendPGN = function (msg) {
       }
     }
   }
-}
-
-function getPlainPGNs(buffer) {
-  var res = []
-  var bucket = 0x40
-
-  var first = new Buffer(8)
-  first.writeUInt8(bucket++, 0)
-  first.writeUInt8(buffer.length, 1)
-  buffer.copy(first, 2, 0, 6)
-  res.push(first)
-
-  for ( var index = 6; index < buffer.length; index += 7 ) {
-    var next = new Buffer(8)
-    next.writeUInt8(bucket++, 0)
-    var end = index+7
-    var fill = 0
-    if ( end > buffer.length ) {
-      fill = end - buffer.length
-      end = buffer.length
-    }
-    buffer.copy(next, 1, index, end)
-    if ( fill > 0 ) {
-      for ( var i = end-index; i < 8; i++ ) {
-        next.writeUInt8(0xff, i)
-      }
-    }
-    res.push(next)
-  }
-  return res
 }
 
 function readLine(that, line) {

--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -279,14 +279,14 @@ class Parser extends EventEmitter {
   }  
 
   //Yacht Devices NMEA2000 Wifi gateway
-  parseYDWG02(pgn_data) {
+  parseYDWG02(pgn_data, cb) {
     const parts = pgn_data.split(' ')
     if ( parts.length != 11 ) return undefined
     const [ time, direction, canId, ...data ] = parts
     const pgn = getPGNFromCanId(parseInt(canId, 16))
     pgn.timestamp = parseDate(time, 'HH:mm:ss.SSS', new Date()).toISOString()
     const bs = new BitStream(Buffer.from(data.join(''), 'hex'))
-    if ( this._parse(pgn, bs, 8) ) {
+    if ( this._parse(pgn, bs, bs.length, cb) ) {
       debug('parsed pgn %j', pgn)
     }
   }

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -19,7 +19,7 @@ const _ = require('lodash')
 const BitStream = require('bit-buffer').BitStream
 const Int64LE = require('int64-buffer').Int64LE
 const Uint64LE = require('int64-buffer').Uint64LE
-const { getManufacturerCode, getIndustryCode } = require('./utilities')
+const { getManufacturerCode, getIndustryCode, getCanIdFromYdwgPGN } = require('./utilities')
 
 const RES_STRINGLAU = 'ASCII or UNICODE string starting with length and control byte'
 

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -19,7 +19,7 @@ const _ = require('lodash')
 const BitStream = require('bit-buffer').BitStream
 const Int64LE = require('int64-buffer').Int64LE
 const Uint64LE = require('int64-buffer').Uint64LE
-const { getManufacturerCode, getIndustryCode, getCanIdFromYdwgPGN } = require('./utilities')
+const { getPlainPGNs, getManufacturerCode, getIndustryCode, getCanIdFromYdwgPGN } = require('./utilities')
 
 const RES_STRINGLAU = 'ASCII or UNICODE string starting with length and control byte'
 
@@ -296,8 +296,16 @@ function toYdwgRawFormat(pgn, data, dst=255) {
   //canId data
   //19F51323 01 02<CR><LF>
   pgn.dst = dst
-  canId = getCanIdFromYdwgPGN(pgn)
-  return canId.toString(16) + " " + parseInt(data, 2).toString(16)
+  const canId = getCanIdFromYdwgPGN(pgn)
+  return getPlainPGNs(data).map(buffer => {
+    return canId.toString(16) + " " + new Uint32Array(buffer)
+      .reduce(function(acc, i) {
+        acc.push(i.toString(16));
+        return acc;
+      }, [])
+      .map(x => (x.length === 1 ? "0" + x : x))
+      .join(" ")
+  })
 }
 
 function pgnToYdwgRawFormat(pgn) {

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -286,20 +286,22 @@ function toActisenseSerialFormat(pgn, data, dst=255, src=0) {
 
 function toiKonvertSerialFormat(pgn, data, dst=255) {
   return `!PDGY,${pgn},${dst},${data.toString('base64')}`
-  /*
-  return `!PDGY,${pgn},${dst},` +
-    new Uint32Array(data)
-    .reduce(function(acc, i) {
-      acc.push(i.toString(16));
-      return acc;
-    }, [])
-    .map(x => (x.length === 1 ? "0" + x : x))
-    .join('')
-  */
 }
 
 function pgnToiKonvertSerialFormat(pgn) {
   return toiKonvertSerialFormat(pgn.pgn, toPgn(pgn), pgn.dst)
+}
+
+function toYdwgRawFormat(pgn, data, dst=255) {
+  //canId data
+  //19F51323 01 02<CR><LF>
+  pgn.dst = dst
+  canId = getCanIdFromPGN(pgn)
+  return candId.toString(16) + " " + parseInt(data, 2).toString(16)
+}
+
+function pgnToYdwgRawFormat(pgn) {
+  return toYDWGRawFormat(pgn.pgn, toPgn(pgn), pgn.dst)
 }
 
 fieldTypeWriters['ASCII text'] = (field, value, bs) => {

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -301,7 +301,7 @@ function toYdwgRawFormat(pgn, data, dst=255) {
 }
 
 function pgnToYdwgRawFormat(pgn) {
-  return toYDWGRawFormat(pgn.pgn, toPgn(pgn), pgn.dst)
+  return toYdwgRawFormat(pgn.pgn, toPgn(pgn), pgn.dst)
 }
 
 fieldTypeWriters['ASCII text'] = (field, value, bs) => {

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -298,7 +298,7 @@ function toYdwgRawFormat(pgn, data, dst=255) {
   pgn.dst = dst
   const canId = getCanIdFromYdwgPGN(pgn)
   return getPlainPGNs(data).map(buffer => {
-    return canId.toString(16) + " " + new Uint32Array(buffer)
+    return canId.toString(16).padStart(8, '0') + " " + new Uint32Array(buffer)
       .reduce(function(acc, i) {
         acc.push(i.toString(16));
         return acc;

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -297,7 +297,8 @@ function toYdwgRawFormat(pgn, data, dst=255) {
   //19F51323 01 02<CR><LF>
   pgn.dst = dst
   const canId = getCanIdFromYdwgPGN(pgn)
-  return getPlainPGNs(data).map(buffer => {
+  const pgns = data.length > 8 ? getPlainPGNs(data) : [ data ]
+  return pgns.map(buffer => {
     return canId.toString(16).padStart(8, '0') + " " + new Uint32Array(buffer)
       .reduce(function(acc, i) {
         acc.push(i.toString(16));

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -398,3 +398,4 @@ module.exports.toPgn = toPgn
 module.exports.toActisenseSerialFormat = toActisenseSerialFormat
 module.exports.toiKonvertSerialFormat = toiKonvertSerialFormat
 module.exports.pgnToiKonvertSerialFormat = pgnToiKonvertSerialFormat
+module.exports.pgnToYdwgRawFormat = pgnToYdwgRawFormat

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -296,7 +296,7 @@ function toYdwgRawFormat(pgn, data, dst=255) {
   //canId data
   //19F51323 01 02<CR><LF>
   pgn.dst = dst
-  canId = getCanIdFromPGN(pgn)
+  canId = getCanIdFromYdwgPGN(pgn)
   return candId.toString(16) + " " + parseInt(data, 2).toString(16)
 }
 

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -297,7 +297,7 @@ function toYdwgRawFormat(pgn, data, dst=255) {
   //19F51323 01 02<CR><LF>
   pgn.dst = dst
   canId = getCanIdFromYdwgPGN(pgn)
-  return candId.toString(16) + " " + parseInt(data, 2).toString(16)
+  return canId.toString(16) + " " + parseInt(data, 2).toString(16)
 }
 
 function pgnToYdwgRawFormat(pgn) {

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -309,7 +309,7 @@ function toYdwgRawFormat(pgn, data, dst=255) {
 }
 
 function pgnToYdwgRawFormat(pgn) {
-  return toYdwgRawFormat(pgn.pgn, toPgn(pgn), pgn.dst)
+  return toYdwgRawFormat(pgn, toPgn(pgn), pgn.dst)
 }
 
 fieldTypeWriters['ASCII text'] = (field, value, bs) => {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -294,6 +294,7 @@ const defaultTransmitPGNs = [
 ]
 
 module.exports.getCanIdFromPGN = getCanIdFromPGN
+module.exports.getCanIdFromYdwgPGN = getCanIdFromYdwgPGN
 module.exports.getPGNFromCanId = getPGNFromCanId
 module.exports.actisenseSerialToBuffer = actisenseSerialToBuffer
 module.exports.getIndustryName = getIndustryName

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -274,6 +274,37 @@ function getDeviceClassName(code) {
   return deviceClassCodes[code]
 }
 
+function getPlainPGNs(buffer) {
+  var res = []
+  var bucket = 0x40
+
+  var first = new Buffer(8)
+  first.writeUInt8(bucket++, 0)
+  first.writeUInt8(buffer.length, 1)
+  buffer.copy(first, 2, 0, 6)
+  res.push(first)
+
+  for ( var index = 6; index < buffer.length; index += 7 ) {
+    var next = new Buffer(8)
+    next.writeUInt8(bucket++, 0)
+    var end = index+7
+    var fill = 0
+    if ( end > buffer.length ) {
+      fill = end - buffer.length
+      end = buffer.length
+    }
+    buffer.copy(next, 1, index, end)
+    if ( fill > 0 ) {
+      for ( var i = end-index; i < 8; i++ ) {
+        next.writeUInt8(0xff, i)
+      }
+    }
+    res.push(next)
+  }
+  return res
+}
+
+
 const defaultTransmitPGNs = [
   60928,
   59904,
@@ -304,3 +335,4 @@ module.exports.getManufacturerCode = getManufacturerCode
 module.exports.getDeviceClassName = getDeviceClassName
 module.exports.getDeviceClassCode = getDeviceClassCode
 module.exports.defaultTransmitPGNs = defaultTransmitPGNs
+module.exports.getPlainPGNs = getPlainPGNs

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -39,7 +39,7 @@ function getPGNFromCanId(id) {
 
 function getCanIdFromPGN(pgn)
 {
-  var canId = pgn.src | 0x80000000;  // src bits are the lowest ones of the CAN ID. Also set the highest bit to 1 as n2k uses only extended frames (EFF bit).
+  var canId = pgn.src | 0x0000000;  // src bits are the lowest ones of the CAN ID. Also set the highest bit to 1 as n2k uses only extended frames (EFF bit).
 
   if((pgn.pgn & 0xff) == 0) {  // PDU 1 (assumed if 8 lowest bits of the PGN are 0)
     canId += (pgn.dst << 8)

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -39,6 +39,23 @@ function getPGNFromCanId(id) {
 
 function getCanIdFromPGN(pgn)
 {
+  var canId = pgn.src | 0x80000000;  // src bits are the lowest ones of the CAN ID. Also set the highest bit to 1 as n2k uses only extended frames (EFF bit).
+
+  if((pgn.pgn & 0xff) == 0) {  // PDU 1 (assumed if 8 lowest bits of the PGN are 0)
+    canId += (pgn.dst << 8)
+    canId += (pgn.pgn << 8)
+    canId += pgn.prio << 26;
+  } else {                       // PDU 2
+    canId += pgn.pgn << 8;
+    canId += pgn.prio << 26;
+  }
+
+  return canId;
+}
+
+//used for the YDWG-02
+function getCanIdFromYdwgPGN(pgn)
+{
   var canId = pgn.src | 0x0000000;  // src bits are the lowest ones of the CAN ID. Also set the highest bit to 1 as n2k uses only extended frames (EFF bit).
 
   if((pgn.pgn & 0xff) == 0) {  // PDU 1 (assumed if 8 lowest bits of the PGN are 0)

--- a/lib/ydwg02.js
+++ b/lib/ydwg02.js
@@ -20,6 +20,8 @@ const FromPgn = require('./fromPgn').Parser
 const _ = require('lodash')
 const { getCanIdFromYdwgPGN, getPGNFromCanId, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
 
+const pgnsSent = {}
+const rateLimit = 200
 
 function Ydwg02Stream (options) {
   if (!(this instanceof Ydwg02Stream)) {
@@ -52,11 +54,10 @@ function Ydwg02Stream (options) {
     options.app.on('nmea2000out', (msg) => {
       that.sendYdwgPGN(msg)
     })
-    /*
+
     options.app.on('nmea2000JsonOut', (msg) => {
       that.sendPGN(msg)
     })
-    */
 
     //this.sendString('$PDGY,N2NET_OFFLINE')
 
@@ -69,6 +70,18 @@ function Ydwg02Stream (options) {
 Ydwg02Stream.prototype.sendString = function (msg) {
   debug('sending %s', msg)
   this.options.app.emit('ydwg02-out', msg)
+}
+
+Ydwg02Stream.prototype.sendPGN = function (pgn) {
+  if ( this.cansend ) {
+    let now = Date.now()
+    let lastSent = pgnsSent[pgn.pgn]
+    if ( !lastSent || now - lastSent > rateLimit ) {
+      let msg = pgnToYdwgRawFormat(pgn)
+      this.sendString(msg)
+      pgnsSent[pgn.pgn] = now
+    }
+  }
 }
 
 Ydwg02Stream.prototype.sendYdwgPGN = function (msg) {

--- a/lib/ydwg02.js
+++ b/lib/ydwg02.js
@@ -78,8 +78,9 @@ Ydwg02Stream.prototype.sendPGN = function (pgn) {
   let now = Date.now()
   let lastSent = pgnsSent[pgn.pgn]
   if ( !lastSent || now - lastSent > rateLimit ) {
-    let msg = pgnToYdwgRawFormat(pgn)
-    this.sendString(msg)
+    pgnToYdwgRawFormat(pgn).forEach(raw => {
+      this.sendString(raw)
+    })
     pgnsSent[pgn.pgn] = now
   }
 }
@@ -98,8 +99,9 @@ Ydwg02Stream.prototype.sendYdwgPGN = function (msg) {
       let now = Date.now()
       let lastSent = pgnsSent[pgn.pgn]
       if ( !lastSent || now - lastSent > rateLimit ) {
-        let msg = pgnToYdwgRawFormat(pgn)
-        that.sendString(msg)
+        pgnToYdwgRawFormat(pgn).forEach(raw => {
+          this.sendString(raw)
+        })
         pgnsSent[pgn.pgn] = now
       }
     })

--- a/lib/ydwg02.js
+++ b/lib/ydwg02.js
@@ -68,7 +68,7 @@ function Ydwg02Stream (options) {
 
 Ydwg02Stream.prototype.sendString = function (msg) {
   debug('sending %s', msg)
-  this.options.app.emit('ydwgOut', msg)
+  this.options.app.emit('ydwg02-out', msg)
 }
 
 Ydwg02Stream.prototype.sendYdwgPGN = function (msg) {

--- a/lib/ydwg02.js
+++ b/lib/ydwg02.js
@@ -18,7 +18,7 @@ const debug = require('debug')('canboatjs:ydwg02')
 const Transform = require('stream').Transform
 const FromPgn = require('./fromPgn').Parser
 const _ = require('lodash')
-const { getPGNFromCanId, getCanIdFromPGN, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
+const { getCanIdFromYdwgPGN, getPGNFromCanId, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
 
 
 function Ydwg02Stream (options) {

--- a/lib/ydwg02.js
+++ b/lib/ydwg02.js
@@ -19,6 +19,7 @@ const Transform = require('stream').Transform
 const FromPgn = require('./fromPgn').Parser
 const _ = require('lodash')
 const { getCanIdFromYdwgPGN, getPGNFromCanId, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
+const { pgnToYdwgRawFormat } = require('./toPgn')
 
 const pgnsSent = {}
 const rateLimit = 200
@@ -52,11 +53,11 @@ function Ydwg02Stream (options) {
 
   if ( this.options.app ) {
     options.app.on('nmea2000out', (msg) => {
-      that.sendYdwgPGN(msg)
+      this.sendYdwgPGN(msg)
     })
 
     options.app.on('nmea2000JsonOut', (msg) => {
-      that.sendPGN(msg)
+      this.sendPGN(msg)
     })
 
     //this.sendString('$PDGY,N2NET_OFFLINE')
@@ -73,40 +74,36 @@ Ydwg02Stream.prototype.sendString = function (msg) {
 }
 
 Ydwg02Stream.prototype.sendPGN = function (pgn) {
-  if ( this.cansend ) {
-    let now = Date.now()
-    let lastSent = pgnsSent[pgn.pgn]
-    if ( !lastSent || now - lastSent > rateLimit ) {
-      let msg = pgnToYdwgRawFormat(pgn)
-      this.sendString(msg)
-      pgnsSent[pgn.pgn] = now
-    }
+  let now = Date.now()
+  let lastSent = pgnsSent[pgn.pgn]
+  if ( !lastSent || now - lastSent > rateLimit ) {
+    let msg = pgnToYdwgRawFormat(pgn)
+    this.sendString(msg)
+    pgnsSent[pgn.pgn] = now
   }
 }
 
 Ydwg02Stream.prototype.sendYdwgPGN = function (msg) {
-  if ( this.cansend ) {
-    if ( !this.parser ) {
-      this.parser = new Parser()
+  if ( !this.parser ) {
+    this.parser = new Parser()
 
-      let that = this
-      this.parser.on('error', (pgn, error) => {
-        console.error(`Error parsing ${pgn.pgn} ${error}`)
-        console.error(error.stack)
-      })
+    let that = this
+    this.parser.on('error', (pgn, error) => {
+      console.error(`Error parsing ${pgn.pgn} ${error}`)
+      console.error(error.stack)
+    })
 
-      this.parser.on('pgn', (pgn) => {
-        let now = Date.now()
-        let lastSent = pgnsSent[pgn.pgn]
-        if ( !lastSent || now - lastSent > rateLimit ) {
-          let msg = pgnToYdwgRawFormat(pgn)
-          that.sendString(msg)
-          pgnsSent[pgn.pgn] = now
-        }
-      })
-    }
-    this.parser.parseString(msg)
+    this.parser.on('pgn', (pgn) => {
+      let now = Date.now()
+      let lastSent = pgnsSent[pgn.pgn]
+      if ( !lastSent || now - lastSent > rateLimit ) {
+        let msg = pgnToYdwgRawFormat(pgn)
+        that.sendString(msg)
+        pgnsSent[pgn.pgn] = now
+      }
+    })
   }
+  this.parser.parseString(msg)
 }
 
 require('util').inherits(Ydwg02Stream, Transform)

--- a/lib/ydwg02.js
+++ b/lib/ydwg02.js
@@ -17,6 +17,7 @@
 const debug = require('debug')('canboatjs:ydwg02')
 const Transform = require('stream').Transform
 const FromPgn = require('./fromPgn').Parser
+const Parser = require('./fromPgn').Parser
 const _ = require('lodash')
 const { getCanIdFromYdwgPGN, getPGNFromCanId, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
 const { pgnToYdwgRawFormat } = require('./toPgn')

--- a/lib/ydwg02.js
+++ b/lib/ydwg02.js
@@ -18,6 +18,8 @@ const debug = require('debug')('canboatjs:ydwg02')
 const Transform = require('stream').Transform
 const FromPgn = require('./fromPgn').Parser
 const _ = require('lodash')
+const { getPGNFromCanId, getCanIdFromPGN, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
+
 
 function Ydwg02Stream (options) {
   if (!(this instanceof Ydwg02Stream)) {
@@ -43,23 +45,55 @@ function Ydwg02Stream (options) {
 
   this.fromPgn.on('error', (pgn, error) => {
     debug(`[error] ${pgn.pgn} ${error}`)
-  })  
+  })
 
-  /*
+
   if ( this.options.app ) {
     options.app.on('nmea2000out', (msg) => {
-      that.sendActisensePGN(msg)
+      that.sendYdwgPGN(msg)
     })
+    /*
     options.app.on('nmea2000JsonOut', (msg) => {
       that.sendPGN(msg)
     })
+    */
 
-    this.sendString('$PDGY,N2NET_OFFLINE')
+    //this.sendString('$PDGY,N2NET_OFFLINE')
 
     debug('started')
     //this.options.app.emit('nmea2000OutAvailable')
   }
-  */
+
+}
+
+Ydwg02Stream.prototype.sendString = function (msg) {
+  debug('sending %s', msg)
+  this.options.app.emit('ydwgOut', msg)
+}
+
+Ydwg02Stream.prototype.sendYdwgPGN = function (msg) {
+  if ( this.cansend ) {
+    if ( !this.parser ) {
+      this.parser = new Parser()
+
+      let that = this
+      this.parser.on('error', (pgn, error) => {
+        console.error(`Error parsing ${pgn.pgn} ${error}`)
+        console.error(error.stack)
+      })
+
+      this.parser.on('pgn', (pgn) => {
+        let now = Date.now()
+        let lastSent = pgnsSent[pgn.pgn]
+        if ( !lastSent || now - lastSent > rateLimit ) {
+          let msg = pgnToYdwgRawFormat(pgn)
+          that.sendString(msg)
+          pgnsSent[pgn.pgn] = now
+        }
+      })
+    }
+    this.parser.parseString(msg)
+  }
 }
 
 require('util').inherits(Ydwg02Stream, Transform)
@@ -69,7 +103,7 @@ Ydwg02Stream.prototype._transform = function (chunk, encoding, done) {
   let line = chunk.toString().trim()
   //line = line.substring(0, line.length) // take off the \r
 
-  this.fromPgn.parseYDWG02(line)  
+  this.fromPgn.parseYDWG02(line)
   done()
 }
 

--- a/test/ydwg02.js
+++ b/test/ydwg02.js
@@ -16,7 +16,7 @@ describe('Convert Yacht Devices RAW format data', function () {
         "prio":2,
         "dst":255,
         "pgn":129025,
-        "timestamp":"T21:29:27.082Z",
+        "timestamp":"T16:29:27.082Z",
         "fields": {
           "Latitude":33.0875728,
           "Longitude":-97.0205113}
@@ -38,7 +38,7 @@ describe('Convert Yacht Devices RAW format data', function () {
         "prio":3,
         "dst":255,
         "pgn":129029,
-        "timestamp":"T21:29:27.990Z",
+        "timestamp":"T16:29:27.990Z",
         "fields": {
           "SID":0,
           "Date":"2019.02.17",
@@ -84,7 +84,7 @@ describe('Convert Yacht Devices RAW format data', function () {
           delete pgn.timestamp
           timestamp.should.endWith(test.expected.timestamp)
           delete test.expected.timestamp
-          
+
           pgn.should.jsonEqual(test.expected)
           done()
         } catch ( e ) {


### PR DESCRIPTION
The YDWG-02 uses a raw format described in http://www.yachtd.com/downloads/ydwg02.pdf

The format of messages sent from application to Device is the same, but without time
and direction field. Outgoing messages must end with <CR><LF>. If the message
from application is accepted, passes filters and is transmitted to NMEA 2000,
it will be sent back to the application with ‘T’ direction.
For example, the application sends the following sentence to the Device:
19F51323 01 02<CR><LF>
When this message is sent to the NMEA 2000 network, the Application receives
an answer like:
17:33:21.108 T 19F51323 01 02<CR><LF>

Closes #49 