### PR TITLE
style: remove unused imports

### DIFF
--- a/lib/candevice.js
+++ b/lib/candevice.js
@@ -18,7 +18,7 @@ const debug = require('debug')('canboatjs:candevice')
 const EventEmitter = require('events')
 const _ = require('lodash')
 const Uint64LE = require('int64-buffer').Uint64LE
-const { getManufacturerCode, getIndustryCode, getDeviceClassCode, getCanIdFromPGN, defaultTransmitPGNs } = require('./utilities')
+const { getManufacturerCode, getIndustryCode, getDeviceClassCode, defaultTransmitPGNs } = require('./utilities')
 const { toPgn } = require('./toPgn')
 
 const addressClaim = {

--- a/lib/ikonvert.js
+++ b/lib/ikonvert.js
@@ -24,7 +24,7 @@ const Parser = require('./fromPgn').Parser
 const _ = require('lodash')
 const CanDevice = require('./candevice')
 const spawn = require('child_process').spawn
-const { getPGNFromCanId, getCanIdFromPGN, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
+const { getPGNFromCanId, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
 
 const pgnsSent = {}
 const rateLimit = 200

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -37,8 +37,7 @@ function getPGNFromCanId(id) {
   return res
 }
 
-function getCanIdFromPGN(pgn)
-{
+function getCanIdFromPGN(pgn) {
   var canId = pgn.src | 0x80000000;  // src bits are the lowest ones of the CAN ID. Also set the highest bit to 1 as n2k uses only extended frames (EFF bit).
 
   if((pgn.pgn & 0xff) == 0) {  // PDU 1 (assumed if 8 lowest bits of the PGN are 0)


### PR DESCRIPTION
candevice and iKonvert were importing `getCanIdFromPGN` but not using it. I removed the import and changed style of a curly on same line a function within utilities.