### PR TITLE
chore: s/getPGNFromCanId/parseCanId s/getCanIdFromPGN/encodeCanId

### DIFF
--- a/lib/canId.js
+++ b/lib/canId.js
@@ -1,7 +1,7 @@
 // Decode CAN Identifier (canId). ISO 11783 (CAN 2.0 B Extended Frame Format)
 exports.parseCanId = (id) => {
   const res = {
-    canId: id,
+    canId: id, // Include original canId in return object.
     src: id & 0xff, // Source Address (SA)
     prio: ((id >> 26) & 0x7), // Priority
   }

--- a/lib/canId.js
+++ b/lib/canId.js
@@ -1,0 +1,33 @@
+// Decode CAN Identifier (canId). ISO 11783 (CAN 2.0 B Extended Frame Format)
+exports.parseCanId = (id) => {
+  const res = {
+    canId: id,
+    src: id & 0xff, // Source Address (SA)
+    prio: ((id >> 26) & 0x7), // Priority
+  }
+  const PF = (id >> 16) & 0xff // PDU Format
+  const PS = (id >> 8) & 0xff // PDU Specific
+  const DP =  (id >> 24) & 1 // Data Page
+
+  if (PF < 240) {
+    /* PDU1 format, the PS contains the destination address */
+    res.dst = PS;
+    res.pgn = (DP << 16) + (PF << 8);
+  } else {
+    /* PDU2 format, the destination is implied global and the PGN is extended */
+    res.dst = 0xff
+    res.pgn = (DP << 16) + (PF << 8) + PS
+  }
+  return res
+}
+
+// Encode CAN Identifier (canId)
+exports.encodeCanId = ({ dst, pgn, prio, src }) => {
+  // src bits are the lowest ones of the CAN ID. prio bits are highest.
+  const canId = src | (prio << 26) | (pgn << 8)
+  // PDU 1 (assumed if 8 lowest bits of the PGN are 0)
+  return ((pgn & 0xff) === 0) ? canId | (dst << 8) : canId
+}
+
+// Utility function that parses and re-encodes. Compare result to original.
+exports.parseEncode = x => exports.encodeCanId(exports.parseCanId(x))

--- a/lib/canId.test.js
+++ b/lib/canId.test.js
@@ -1,0 +1,33 @@
+const { encodeCanId, parseCanId, parseEncode } = require('./canId')
+
+/* globals describe test expect */
+
+describe('parseCanId', () => {
+  test('Return object with canId broken into properties', () => {
+    expect(parseCanId(0x18eeff01)).toEqual({
+      canId: 0x18eeff01, dst: 255, src: 1, pgn: 60928, prio: 6,
+    })
+    expect(parseCanId(0xCF004EE)).toEqual({
+      canId: 0xCF004EE, dst: 255, src: 0xEE, pgn: 0xF004, prio: (0xC >> 2),
+    })
+    expect(parseCanId(0x18ea2301)).toEqual({
+      canId: 0x18ea2301, dst: 35, src: 0x01, pgn: 0xEA00, prio: 6,
+    })
+  })
+})
+describe('encodeCanId', () => {
+  test('Return canId number from object', () => {
+    expect(encodeCanId({ src: 1, pgn: 60928, prio: 6, dst: 255 }).toString(2))
+      .toBe(0x18eeff01.toString(2))
+    expect((encodeCanId({ src: 238, pgn: 61444, prio: 3 })))
+      .toBe((0xCF004EE))
+  })
+})
+
+describe('parseEncode', () => {
+  test('Return exactly same number after parse and encode', () => {
+    expect(parseEncode(0x18eeff01)).toBe(0x18eeff01)
+    expect(parseEncode(0xCF004EE)).toBe(0xCF004EE)
+    expect(parseEncode(0x18ea2301)).toBe(0x18ea2301)
+  })
+})

--- a/lib/canbus.js
+++ b/lib/canbus.js
@@ -24,8 +24,8 @@ const Parser = require('./fromPgn').Parser
 const _ = require('lodash')
 const CanDevice = require('./candevice')
 const spawn = require('child_process').spawn
-const { getPlainPGNs, getCanIdFromPGN, actisenseSerialToBuffer } = require('./utilities')
-const { parseCanId } = require('./canId')
+const { getPlainPGNs, actisenseSerialToBuffer } = require('./utilities')
+const { encodeCanId, parseCanId } = require('./canId')
 
 const MSG_BUF_SIZE  			= 2000
 const CANDUMP_DATA_INC_3		= 3
@@ -204,12 +204,12 @@ CanbusStream.prototype.sendPGN = function (msg) {
 
       var pgn
       if ( _.isObject(msg) ) {
-        canid = getCanIdFromPGN(msg)
+        canid = encodeCanId(msg)
         buffer = toPgn(msg)
         pgn = msg
       } else {
         pgn = actisenseSerialToBuffer(msg)
-        canid = getCanIdFromPGN(pgn)
+        canid = encodeCanId(pgn)
         buffer = pgn.data
       }
 

--- a/lib/canbus.js
+++ b/lib/canbus.js
@@ -131,7 +131,7 @@ function CanbusStream (options) {
         if ( that.plainText ) {
           this.push(binToActisense(pgn, msg.data, msg.data.length))
         } else {
-          that.push({pgn: pgn, length: msg.data.length, data:msg.data})
+          that.push({ pgn, length: msg.data.length, data: msg.data })
         }
       })
       this.channel.start()
@@ -277,7 +277,7 @@ function readLine(that, line) {
 
   pgn.timestamp = new Date().toISOString()
 
-  that.push({pgn: pgn, length: len, data:data})
+  that.push({ pgn: pgn, length: len, data })
 }
 
 CanbusStream.prototype._transform = function (chunk, encoding, done) {

--- a/lib/canbus.js
+++ b/lib/canbus.js
@@ -24,7 +24,8 @@ const Parser = require('./fromPgn').Parser
 const _ = require('lodash')
 const CanDevice = require('./candevice')
 const spawn = require('child_process').spawn
-const { getPlainPGNs, getPGNFromCanId, getCanIdFromPGN, actisenseSerialToBuffer } = require('./utilities')
+const { getPlainPGNs, getCanIdFromPGN, actisenseSerialToBuffer } = require('./utilities')
+const { parseCanId } = require('./canId')
 
 const MSG_BUF_SIZE  			= 2000
 const CANDUMP_DATA_INC_3		= 3
@@ -120,7 +121,7 @@ function CanbusStream (options) {
     try {
       this.channel = socketcan.createRawChannel(canDevice);
       this.channel.addListener('onMessage', (msg) => {
-        var pgn = getPGNFromCanId(msg.id)
+        var pgn = parseCanId(msg.id)
 
         if ( that.candevice && that.candevice.cansend && pgn.src == that.candevice.address ) {
           return
@@ -266,7 +267,7 @@ function readLine(that, line) {
   }
 
   //console.log(JSON.stringify(split))
-  var pgn = getPGNFromCanId(canid)
+  var pgn = parseCanId(canid)
 
   if ( that.candevice && pgn.src == that.candevice.address ) {
     //this is a message that we sent

--- a/lib/candevice.js
+++ b/lib/candevice.js
@@ -18,7 +18,7 @@ const debug = require('debug')('canboatjs:candevice')
 const EventEmitter = require('events')
 const _ = require('lodash')
 const Uint64LE = require('int64-buffer').Uint64LE
-const { getManufacturerCode, getIndustryCode, getDeviceClassCode, getCanIdFromPGN, defaultTransmitPGNs } = require('./utilities')
+const { getManufacturerCode, getIndustryCode, getDeviceClassCode, defaultTransmitPGNs } = require('./utilities')
 const { toPgn } = require('./toPgn')
 
 const addressClaim = {

--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -25,7 +25,8 @@ const BitView = require('bit-buffer').BitView
 const Int64LE = require('int64-buffer').Int64LE
 const Uint64LE = require('int64-buffer').Uint64LE
 const { parse: parseDate } = require('date-fns')
-const { getPGNFromCanId, getManufacturerName, getIndustryName } = require('./utilities')
+const { getManufacturerName, getIndustryName } = require('./utilities')
+const { parseCanId } = require('./canId')
 
 var fieldTypeReaders = {}
 var fieldTypePostProcessors = {}
@@ -246,7 +247,7 @@ class Parser extends EventEmitter {
     } catch ( error ) {
       this.emit('error', pgn, error)
       cb && cb(error)
-      return 
+      return
     }
   }
 
@@ -282,7 +283,7 @@ class Parser extends EventEmitter {
   isN2KOver0183(sentence) {
     return sentence.startsWith('$PCDIN,')
   }
-  
+
   parseN2KOver0183(sentence, cb) {
     if ( sentence.startsWith('$PCDIN,') ) {
       return this.parsePCDIN(sentence, cb)
@@ -313,7 +314,7 @@ class Parser extends EventEmitter {
     if ( parts.length < 4 ) return undefined
     const [ time, direction, canId, ...data ] = parts
     if ( direction === 'R' ) {
-      const pgn = getPGNFromCanId(parseInt(canId, 16))
+      const pgn = parseCanId(parseInt(canId, 16))
       pgn.timestamp = parseDate(time, 'HH:mm:ss.SSS', new Date()).toISOString()
       const bs = new BitStream(Buffer.from(data.join(''), 'hex'))
       const res = this._parse(pgn, bs, data.length, cb)
@@ -334,14 +335,14 @@ class Parser extends EventEmitter {
     pgn.src = parseInt(split[3], 16)
     pgn.dst = 255
     pgn.prio = 0
-    
+
     var data = split[4]
     if ( data.indexOf('*') != -1 ) {
       data = data.split('*')[0]
     }
-    
+
     const bs = new BitStream(Buffer.from(data, 'hex'))
-    
+
     const res = this._parse(pgn, bs, data.length/2, cb)
     if ( res ) {
       debug('parsed pgn %j', pgn)
@@ -355,7 +356,7 @@ class Parser extends EventEmitter {
       if ( this.isN2KOver0183(pgn_data) ) {
         return this.parseN2KOver0183(pgn_data, cb)
       }
-      
+
       var split = pgn_data.split(',')
 
       var pgn = {}

--- a/lib/ikonvert.js
+++ b/lib/ikonvert.js
@@ -24,7 +24,8 @@ const Parser = require('./fromPgn').Parser
 const _ = require('lodash')
 const CanDevice = require('./candevice')
 const spawn = require('child_process').spawn
-const { getPGNFromCanId, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
+const { actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
+const { parseCanId } = require('./canId')
 
 const pgnsSent = {}
 const rateLimit = 200

--- a/lib/ikonvert.js
+++ b/lib/ikonvert.js
@@ -24,7 +24,7 @@ const Parser = require('./fromPgn').Parser
 const _ = require('lodash')
 const CanDevice = require('./candevice')
 const spawn = require('child_process').spawn
-const { getPGNFromCanId, getCanIdFromPGN, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
+const { getPGNFromCanId, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
 
 const pgnsSent = {}
 const rateLimit = 200

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -16,42 +16,6 @@
 
 const _ = require('lodash')
 
-function getPGNFromCanId(id) {
-  var res = {}
-  var PF = (id >> 16) & 0xff
-  var PS = (id >> 8) & 0xff
-  var DP =  (id >> 24) & 1
-
-  res.src = id >> 0 & 0xff
-  res.prio = ((id >> 26) & 0x7)
-
-  if (PF < 240) {
-    /* PDU1 format, the PS contains the destination address */
-    res.dst = PS;
-    res.pgn = (DP << 16) + (PF << 8);
-  } else {
-    /* PDU2 format, the destination is implied global and the PGN is extended */
-    res.dst = 0xff
-    res.pgn = (DP << 16) + (PF << 8) + PS
-  }
-  return res
-}
-
-function getCanIdFromPGN(pgn) {
-  var canId = pgn.src | 0x80000000;  // src bits are the lowest ones of the CAN ID. Also set the highest bit to 1 as n2k uses only extended frames (EFF bit).
-
-  if((pgn.pgn & 0xff) == 0) {  // PDU 1 (assumed if 8 lowest bits of the PGN are 0)
-    canId += (pgn.dst << 8)
-    canId += (pgn.pgn << 8)
-    canId += pgn.prio << 26;
-  } else {                       // PDU 2
-    canId += pgn.pgn << 8;
-    canId += pgn.prio << 26;
-  }
-
-  return canId;
-}
-
 //used for the YDGW-02
 function getCanIdFromYdgwPGN(pgn)
 {
@@ -326,7 +290,6 @@ const defaultTransmitPGNs = [
 
 module.exports.getCanIdFromPGN = getCanIdFromPGN
 module.exports.getCanIdFromYdgwPGN = getCanIdFromYdgwPGN
-module.exports.getPGNFromCanId = getPGNFromCanId
 module.exports.actisenseSerialToBuffer = actisenseSerialToBuffer
 module.exports.getIndustryName = getIndustryName
 module.exports.getManufacturerName = getManufacturerName

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -37,8 +37,7 @@ function getPGNFromCanId(id) {
   return res
 }
 
-function getCanIdFromPGN(pgn)
-{
+function getCanIdFromPGN(pgn) {
   var canId = pgn.src | 0x80000000;  // src bits are the lowest ones of the CAN ID. Also set the highest bit to 1 as n2k uses only extended frames (EFF bit).
 
   if((pgn.pgn & 0xff) == 0) {  // PDU 1 (assumed if 8 lowest bits of the PGN are 0)

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -288,7 +288,6 @@ const defaultTransmitPGNs = [
   127502
 ]
 
-module.exports.getCanIdFromPGN = getCanIdFromPGN
 module.exports.getCanIdFromYdgwPGN = getCanIdFromYdgwPGN
 module.exports.actisenseSerialToBuffer = actisenseSerialToBuffer
 module.exports.getIndustryName = getIndustryName

--- a/lib/ydgw02.js
+++ b/lib/ydgw02.js
@@ -19,7 +19,7 @@ const Transform = require('stream').Transform
 const FromPgn = require('./fromPgn').Parser
 const Parser = require('./fromPgn').Parser
 const _ = require('lodash')
-const { getCanIdFromYdgwPGN, getPGNFromCanId, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
+const { getCanIdFromYdgwPGN, actisenseSerialToBuffer, defaultTransmitPGNs } = require('./utilities')
 const { pgnToYdgwRawFormat, actisenseToYdgwRawFormat } = require('./toPgn')
 
 const pgnsSent = {}
@@ -86,7 +86,7 @@ Ydgw02Stream.prototype.sendYdgwPGN = function (msg) {
   actisenseToYdgwRawFormat(msg).forEach(raw => {
     this.sendString(raw)
   })
-  
+
   /*
   if ( !this.parser ) {
     this.parser = new Parser()
@@ -97,7 +97,7 @@ Ydgw02Stream.prototype.sendYdgwPGN = function (msg) {
       console.error(error.stack)
     })
 
-    
+
     this.parser.on('pgn', (pgn) => {
       let now = Date.now()
       let lastSent = pgnsSent[pgn.pgn]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Native javascript version of canboat",
   "main": "index.js",
   "scripts": {
+    "dev-test": "jest --watch",
     "test": "mocha --exit",
     "create-release": "github-create-release --owner canboat --repository canboatjs",
     "release": "git tag -d v$npm_package_version && git tag v$npm_package_version && git push --tags && git push && npm run create-release"
@@ -14,12 +15,21 @@
     "candumpanalyzerjs": "./bin/candumpanalyzerjs",
     "actisense-serialjs": "./bin/actisense-serialjs"
   },
+  "jest": {
+    "rootDir": "lib"
+  },
   "keywords": [
-    "nmea2000",
-    "signalk",
-    "signal",
+    "boat",
+    "bus",
+    "can",
+    "canboat",
     "k",
-    "parser"
+    "marine",
+    "nmea2000",
+    "parser",
+    "pgn",
+    "signalk",
+    "signal"
   ],
   "author": "Scott Bender <scott@scottbender.net>",
   "contributors": [
@@ -54,13 +64,14 @@
     "chai-json-equal": "0.0.1",
     "chai-string": "^1.5.0",
     "chai-things": "^0.2.0",
+    "jest": "^24.7.1",
     "mocha": "^5.0.0",
     "moment": "^2.24.0"
   },
   "optionalDependencies": {
+    "mdns": "^2.3.4",
     "serialport": "^6.0.0",
-    "socketcan": "^2.2.2",
-    "mdns": "^2.3.4"
+    "socketcan": "^2.2.2"
   },
   "repository": {
     "type": "git",

--- a/test/ydgw02.js
+++ b/test/ydgw02.js
@@ -22,6 +22,7 @@ describe('Convert Yacht Devices RAW format data', function () {
           "Latitude":33.0875728,
           "Longitude":-97.0205113}
         ,
+        canId: 0x09F8017F,
         "description":"Position, Rapid Update"
       }
     },
@@ -57,6 +58,7 @@ describe('Convert Yacht Devices RAW format data', function () {
           "Reference Stations":0,
           "list":[{"Reference Station ID":15}]
           },
+        canId: 0x0DF8057F,
         "description":"GNSS Position Data"
       }
     }


### PR DESCRIPTION
* Moved getPGNFromCanId and getCanIdFromPGN from utilities to canId file
* Renamed getCanIdFromPGN to encodeCanId
* Renamed getPGNFromCanId to parseCanId
* Created function tests for `encodeCanId` and `parseCanId`
* Changed imports to use new location
* Include original `canId` value in parsed result object of `parseCanId`.