### PR TITLE
refactor: rm getCanIdFromYdgwPGN use encodeCanId instead

### DIFF
--- a/lib/canId.test.js
+++ b/lib/canId.test.js
@@ -35,5 +35,7 @@ describe('parseEncode', () => {
     expect(parseEncode(0x18eeff01)).toBe(0x18eeff01)
     expect(parseEncode(0xCF004EE)).toBe(0xCF004EE)
     expect(parseEncode(0x18ea2301)).toBe(0x18ea2301)
+    expect(parseEncode(0x09F8017F)).toBe(0x09F8017F)
+    expect(parseEncode(0x0DF8057F)).toBe(0x0DF8057F)
   })
 })

--- a/lib/canId.test.js
+++ b/lib/canId.test.js
@@ -13,6 +13,12 @@ describe('parseCanId', () => {
     expect(parseCanId(0x18ea2301)).toEqual({
       canId: 0x18ea2301, dst: 35, src: 0x01, pgn: 0xEA00, prio: 6,
     })
+    expect(parseCanId(0x09F8017F)).toEqual({
+      canId: 0x09F8017F, dst: 255, src: 127, pgn: 129025, prio: 2,
+    })
+    expect(parseCanId(0x0DF8057F)).toEqual({
+      canId: 0x0DF8057F, dst: 255, src: 127, pgn: 129029, prio: 3,
+    })
   })
 })
 describe('encodeCanId', () => {

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -19,7 +19,8 @@ const _ = require('lodash')
 const BitStream = require('bit-buffer').BitStream
 const Int64LE = require('int64-buffer').Int64LE
 const Uint64LE = require('int64-buffer').Uint64LE
-const { getPlainPGNs, getCanIdFromYdgwPGN , actisenseSerialToBuffer} = require('./utilities')
+const { getPlainPGNs, actisenseSerialToBuffer} = require('./utilities')
+const { encodeCanId } = require('./canId')
 const { getIndustryCode, getManufacturerCode } = require('./codes')
 
 const RES_STRINGLAU = 'ASCII or UNICODE string starting with length and control byte'
@@ -298,7 +299,7 @@ function toYdgwRawFormat(pgn, data, dst=255) {
   //canId data
   //19F51323 01 02<CR><LF>
   pgn.dst = dst
-  const canId = getCanIdFromYdgwPGN(pgn)
+  const canId = encodeCanId(pgn)
   const pgns = data.length > 8 ? getPlainPGNs(data) : [ data ]
   return pgns.map(buffer => {
     return canId.toString(16).padStart(8, '0') + " " + new Uint32Array(buffer)
@@ -317,7 +318,7 @@ function pgnToYdgwRawFormat(pgn) {
 
 function actisenseToYdgwRawFormat(msg) {
   const pgn = actisenseSerialToBuffer(msg)
-  const canId = getCanIdFromYdgwPGN(pgn)
+  const canId = encodeCanId(pgn)
   const pgns = pgn.data.length > 8 ? getPlainPGNs(pgn.data) : [ pgn.data ]
   return pgns.map(buffer => {
     return canId.toString(16).padStart(8, '0') + " " + new Uint32Array(buffer)

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -16,23 +16,6 @@
 
 const _ = require('lodash')
 
-//used for the YDGW-02
-function getCanIdFromYdgwPGN(pgn)
-{
-  var canId = pgn.src | 0x0000000;  // src bits are the lowest ones of the CAN ID. Also set the highest bit to 1 as n2k uses only extended frames (EFF bit).
-
-  if((pgn.pgn & 0xff) == 0) {  // PDU 1 (assumed if 8 lowest bits of the PGN are 0)
-    canId += (pgn.dst << 8)
-    canId += (pgn.pgn << 8)
-    canId += pgn.prio << 26;
-  } else {                       // PDU 2
-    canId += pgn.pgn << 8;
-    canId += pgn.prio << 26;
-  }
-
-  return canId;
-}
-
 const mainFields = [
   'timestamp',
   'prio',
@@ -91,5 +74,4 @@ function getPlainPGNs(buffer) {
 }
 
 module.exports.getPlainPGNs = getPlainPGNs
-module.exports.getCanIdFromYdgwPGN = getCanIdFromYdgwPGN
 module.exports.actisenseSerialToBuffer = actisenseSerialToBuffer

--- a/lib/ydgw02.js
+++ b/lib/ydgw02.js
@@ -19,7 +19,7 @@ const Transform = require('stream').Transform
 const FromPgn = require('./fromPgn').Parser
 const Parser = require('./fromPgn').Parser
 const _ = require('lodash')
-const { getCanIdFromYdgwPGN, actisenseSerialToBuffer } = require('./utilities')
+const { actisenseSerialToBuffer } = require('./utilities')
 const { defaultTransmitPGNs } = require('./codes')
 const { pgnToYdgwRawFormat, actisenseToYdgwRawFormat } = require('./toPgn')
 


### PR DESCRIPTION
I see there was a duplicate way to create a binary `canId` from a `pgn` object for use specific to YDGW-02. I included some code fixes in #61 that hopefully prevent the need for this duplicate method. Do you remember what was failing so we could add some specific tests for it?

Switched to using `encodeCanId` instead of `getCanIdFromYdgwPGN`.