### PR TITLE
chore: Split pgn info processing to own file

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -19,7 +19,7 @@ const trace = require('debug')('canboatjs:fromPgn:trace')
 const EventEmitter = require('events')
 const pkg = require('../package.json')
 const _ = require('lodash')
-const pgns = organizedPGNs()
+const { pgns } = require('./pgns')
 const BitStream = require('bit-buffer').BitStream
 const BitView = require('bit-buffer').BitView
 const Int64LE = require('int64-buffer').Int64LE
@@ -53,37 +53,6 @@ const FASTPACKET_MAX_SIZE = (FASTPACKET_BUCKET_0_SIZE + FASTPACKET_BUCKET_N_SIZE
 
 //we can't handle these, so ignore them
 const ignoredPgns = []//130820, 126720 ]
-
-function organizedPGNs() {
-  const pgns = require('@canboat/pgns')
-  const res = {}
-  pgns.PGNs.forEach(pgn => {
-    if ( !res[pgn.PGN] ) {
-      res[pgn.PGN] = []
-    }
-    res[pgn.PGN].push(pgn)
-    pgn.Fields = _.isArray(pgn.Fields) ? pgn.Fields : (pgn.Fields ? [pgn.Fields.Field] : [])
-    var reservedCount = 1
-    pgn.Fields.forEach((field) => {
-      if ( field.Name === 'Reserved' ) {
-        field.Name = `Reserved${reservedCount++}`
-      }
-    })
-    /*
-    eval(`pgn.create = function(timestamp, prio, pgn, src, dst) {\
-      return {\
-        timestamp: timestamp,\
-        prio: prio,\
-        pgn: pgn,\
-        src: src,\
-        dst: dst,\
-        fields: { ${pgn.fields.map(field => '"' + field.Name+'": null').join(',')} } \
-      }\
-    }`)
-    */
-  })
-  return res
-}
 
 class Parser extends EventEmitter {
   constructor (opts) {
@@ -270,7 +239,7 @@ class Parser extends EventEmitter {
         })
         buffer = new Buffer(array)
       }
-      
+
       var bv = new BitView(buffer);
       var bs = new BitStream(bv)
       const res = this._parse(pgn, bs, length, cb);
@@ -287,7 +256,7 @@ class Parser extends EventEmitter {
   isN2KOver0183(sentence) {
     return isN2KOver0183(sentence)
   }
-  
+
   parseN2KOver0183(sentence, cb) {
     return this.parseString(sentence, cb)
   }
@@ -357,10 +326,11 @@ class Parser extends EventEmitter {
       return res
     } catch ( error ) {
       cb && cb(error)
-      this.emit('error', pgn, error)
+      this.emit('error', pgn_data, error)
     }
   }
 
+  // What uses this? What created the buffer?
   parseBuffer (pgn_data, cb) {
     try {
       var bv = new BitView(pgn_data);
@@ -368,6 +338,7 @@ class Parser extends EventEmitter {
 
       var pgn = {}
 
+      // This might be good to move to canId.js ?
       pgn.prio = bs.readUint8()
       pgn.pgn = bs.readUint8() + 256 * (bs.readUint8() + 256 * bs.readUint8());
       pgn.dst = bs.readUint8()
@@ -624,20 +595,20 @@ fieldTypeReaders['ASCII or UNICODE string starting with length and control byte'
     const len = bs.readUint8()-2
     const control = bs.readUint8()
     let nameLen = len
-    
+
     if ( field.Name === 'AtoN Name' && len > 20 ) {
       nameLen = 20
     } else if ( len == 0 ) {
       return null
     }
-    
+
     var buf = new Buffer(len)
     var idx = 0
     for ( ; idx < len && bs.bitsLeft >= 8; idx++ ) {
       var c = bs.readUint8()
       buf.writeUInt8(c, idx)
     }
-    
+
     return buf.toString(control == 0 ? 'utf8' : 'ascii', 0, idx < nameLen ? idx : nameLen).trim()
   } else {
     return null
@@ -782,7 +753,5 @@ fieldTypePostProcessors['Manufacturer code'] = (field, value) => {
 
 module.exports = {
   Parser: Parser,
-  organizedPGNs: organizedPGNs,
   getField: getField,
-  pgns: pgns
 }

--- a/lib/pgns.js
+++ b/lib/pgns.js
@@ -1,0 +1,41 @@
+const { flow, first, isArray, isEmpty, propertyOf } = require('lodash/fp')
+const pgns = require('@canboat/pgns')
+
+function organizePGNs() {
+  const res = {}
+  pgns.PGNs.forEach(pgn => {
+    if ( !res[pgn.PGN] ) {
+      res[pgn.PGN] = []
+    }
+    res[pgn.PGN].push(pgn)
+    pgn.Fields = isArray(pgn.Fields) ? pgn.Fields : (pgn.Fields ? [pgn.Fields.Field] : [])
+    var reservedCount = 1
+    pgn.Fields.forEach((field) => {
+      if ( field.Name === 'Reserved' ) {
+        field.Name = `Reserved${reservedCount++}`
+      }
+    })
+    /*
+    eval(`pgn.create = function(timestamp, prio, pgn, src, dst) {\
+      return {\
+        timestamp: timestamp,\
+        prio: prio,\
+        pgn: pgn,\
+        src: src,\
+        dst: dst,\
+        fields: { ${pgn.fields.map(field => '"' + field.Name+'": null').join(',')} } \
+      }\
+    }`)
+    */
+  })
+  return res
+}
+
+const organizedPGNs = organizePGNs()
+const getPgn = pgn => organizedPGNs[pgn]
+
+module.exports = {
+  getPgn,
+  getPgn0: flow(getPgn, first),
+  pgns: organizedPGNs,
+}

--- a/lib/pgns.test.js
+++ b/lib/pgns.test.js
@@ -1,0 +1,13 @@
+const { getPgn, getPgn0, pgns } = require('./pgns')
+
+// console.log(pgns)
+describe('getPgn', () => {
+  test('Return info array about a pgn number', () => {
+    expect(getPgn('60928')[0].Description).toBe('ISO Address Claim')
+  })
+})
+describe('getPgn0', () => {
+  test('Return first info object about a pgn number', () => {
+    expect(getPgn0('60928').Description).toBe('ISO Address Claim')
+  })
+})

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-const { pgns, getField } = require('./fromPgn')
+const { getField } = require('./fromPgn')
+const { pgns } = require('./pgns')
 const _ = require('lodash')
 const BitStream = require('bit-buffer').BitStream
 const Int64LE = require('int64-buffer').Int64LE


### PR DESCRIPTION
In the future I think the `@canboat/pgns` package could preprocess the pgn info to clean it up a bit before publishing to NPM. This change will make it easier for that future change by putting the processed pgn data into its own file instead of having it be in `fromPgn.js`. In the future we could swap out `const { pgns } = require('./pgns')` with `const { pgns } = require('@canboat/pgns')`.