### PR TITLE
chore: update serialport for Node 12 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "moment": "^2.24.0"
   },
   "optionalDependencies": {
-    "serialport": "^6.0.0",
+    "serialport": "^7.1.5",
     "socketcan": "^2.2.2"
   },
   "repository": {


### PR DESCRIPTION
Serialport installation fails on Node v12 prior to 7.1.5.
SK Server is already on 7, so having 6 here causes
an extraneous dependency:
```
$ npm list serialport
/tmp
└─┬ signalk-server@1.17.0
  └─┬ @signalk/streams@1.4.0
    ├─┬ @canboat/canboatjs@1.6.10
    │ └── serialport@6.2.2  extraneous
    └── serialport@7.1.5
```