### PR TITLE
fix: broken encoding for PGNs with lenght > 8 for canbus and ydgw

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -373,7 +373,7 @@ function getField(pgn, index) {
   if ( pgnList ) {
     var pgn = pgnList[0]
 
-    if ( index < pgn.Fields.length ) {
+    if ( index >= 0 && index < pgn.Fields.length ) {
       return pgn.Fields[index]
     }
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -38,7 +38,7 @@ function getPlainPGNs(buffer) {
     }
     buffer.copy(next, 1, index, end)
     if ( fill > 0 ) {
-      for ( var i = end-index; i < 8; i++ ) {
+      for ( var i = end-index+1; i < 8; i++ ) {
         next.writeUInt8(0xff, i)
       }
     }


### PR DESCRIPTION
THe last byte of messages was getting overwritten with 0xFF