### PR TITLE
feature: debugOut everything written

### DIFF
--- a/lib/serial.js
+++ b/lib/serial.js
@@ -139,6 +139,7 @@ SerialStream.prototype.start = function () {
         debugOut(`sending ${msg}`)
         var buf = parseInput(msg)
         buf = composeMessage(N2K_MSG_SEND, buf, buf.length)
+        debugOut(buf)
         that.serial.write(buf)
       }
       
@@ -148,6 +149,7 @@ SerialStream.prototype.start = function () {
         debugOut(`sending ${actisense}`)
         var buf = parseInput(actisense)
         buf = composeMessage(N2K_MSG_SEND, buf, buf.length)
+        debugOut(buf)
         that.serial.write(buf)
       }
       
@@ -184,6 +186,7 @@ SerialStream.prototype.start = function () {
         try {
           setProviderStatus(`Connected to ${that.options.device}`)
           var buf = composeMessage(NGT_MSG_SEND, Buffer.from(NGT_STARTUP_MSG), NGT_STARTUP_MSG.length)
+          debugOut(buf)
           that.serial.write(buf)
           debug('sent startup message')
           that.gotStartupResponse = false
@@ -193,6 +196,7 @@ SerialStream.prototype.start = function () {
             setTimeout(() => {
               if ( that.gotStartupResponse === false ) {
                 debug('retry startup message...')
+                debugOut(bug)
                 that.serial.write(buf)
               }
             }, 5000)
@@ -292,7 +296,9 @@ function read1Byte(that, c)
 
 function enableTXPGN(serial, pgn) {
   debug('enabling pgn %d', pgn)
-  serial.write(composeEnablePGN(pgn))
+  const msg = composeEnablePGN(pgn)
+  debugOut(msg)
+  serial.write(msg)
 }
 
 function enableOutput(that) {
@@ -305,7 +311,9 @@ function enableOutput(that) {
 
 function requestTransmitPGNList(that) {
   debug('request tx pgns...')
-  that.serial.write(composeRequestTXPGNList())
+  const requestMsg = composeRequestTXPGNList()
+  debugOut(requestMsg)
+  that.serial.write(requestMsg)
   setTimeout(() => {
     if ( !that.gotTXPGNList ) {
       if ( that.transmitPGNRetries-- > 0 ) {
@@ -406,7 +414,9 @@ function processNTGMessage(that, buffer, len)
         debug('enabled %d', that.neededTransmitPGNs[0])
         that.neededTransmitPGNs = that.neededTransmitPGNs.slice(1)
         if ( that.neededTransmitPGNs.length === 0 ) {
-          that.serial.write(composeCommitTXPGN())
+          const commitMsg = composeCommitTXPGN()
+          debugOut(commitMsg)
+          that.serial.write(msg)
         } else {
           enableTXPGN(that.serial, that.neededTransmitPGNs[0])
         }
@@ -415,7 +425,9 @@ function processNTGMessage(that, buffer, len)
       }
     } else if ( command === 0x01 ) {
       debug('commited tx list')
-      that.serial.write(composeActivateTXPGN())
+      const activateMsg = composeActivateTXPGN()
+      debugOut(activateMsg)
+      that.serial.write(activateMsg)
     } else if ( command === 0x4b ) {
       debug('activated tx list')
       enableOutput(that)


### PR DESCRIPTION
Previously only some of the output data was logged with debugOut
that uses signalk:actisense-out debug key.