### PR TITLE
feat: add $MXPGN support for Shipmodul devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Canboatjs
 
-
-
 [![npm version](https://img.shields.io/npm/v/@canboat/canboatjs.svg)](https://www.npmjs.com/@canboat/canboatjs)
 
 Pure javascript NMEA 2000 decoder and encoder
@@ -9,24 +7,31 @@ Pure javascript NMEA 2000 decoder and encoder
 Canboatjs is a port of the canboat project (https://github.com/canboat/canboat) to javascript
 
 # Contributors
+
 Canboajs js is built on the backs of a few people whithout whom it would not be possible.
+
 - Kees Verruijt <kees@verruijt.net>
 - Jouni Hartikainen <jouni.hartikainen@iki.fi>
 - Teppo Kurki <teppo.kurki@iki.fi>
 
 # Features
 
-- Read directly from an Actisense NGT-1, canbus devices, Digital Yachts' iKonvert and Yacht Devices YDWG-02
-- Supports input in canboat analyzer json format
-- Take input in canboat analyzer json format and convert to binary N2K format and output to supported devices
+- Reads directly from CAN bus devices and NMEA 2000 gateways including:
+  - Actisense NGT-1
+  - Digital Yacht iKonvert
+  - Yacht Devices YDWG-02
+  - Shipmodul MiniPlex-3-N2K
+- Parses input in canboat analyzer json format
+- Converts and outputs binary N2K format to supported devices
 
 # PGN Descriptions
-The details about the PGN's recognized by Canboatjs come from the canboat project in [pgns.json](https://github.com/canboat/pgns). If you want to add or update PGN details, please make changes to the pgn.h file in canboat and submit a pull request there. Include sample data and raise an issue here so that I can include your changes in Canboatjs.
 
+The details about the PGNs recognized by Canboatjs come from the canboat project in [pgns.json](https://github.com/canboat/canboat/blob/master/analyzer/pgns.json). If you want to add or update PGN details, please make changes to the [pgn.h file](https://github.com/canboat/canboat/blob/master/analyzer/pgn.h) in canboat and submit a pull request there. Include sample data and raise an issue here so that I can include your changes in Canboatjs.
 
 # Command Line Programs
 
 ## analyzerjs
+
 This program is similar to the canboat `analyzer` command-line. It takes input in the actisense serial format and outputs canboat json for mat.
 
 Examples:
@@ -36,14 +41,16 @@ Examples:
 - `nc ydgw 1475 | analyzerjs`
 
 ## to-pgn
+
 This program takes input in the canboat json format and outputs actisense serial format.
 
 ## candumpanalyzer
+
 This program takes input in the candump format and outputs canboat json format
 
 Example: `candump can0 | candumpanalyzerjs`
 
-# Use in your own software
+# Usage
 
 ## Installation
 
@@ -52,87 +59,118 @@ Example: `candump can0 | candumpanalyzerjs`
 ## Create the parser
 
 ```js
-const FromPgn = require('@canboat/canboatjs').FromPgn
+const FromPgn = require("@canboat/canboatjs").FromPgn;
 
-const parser = new FromPgn()
+const parser = new FromPgn();
 
-parser.on('warning', (pgn, warning) => {
-  console.log(`[warning] ${pgn.pgn} ${warning}`)
-})
-
+parser.on("warning", (pgn, warning) => {
+  console.log(`[warning] ${pgn.pgn} ${warning}`);
+});
 ```
 
 ## Parse input from the Actisense NGT-1 or iKonvert string formats
 
 ```js
-const json = parser.parseString('2017-03-13T01:00:00.146Z,2,127245,204,255,8,fc,f8,ff,7f,ff,7f,ff,ff')
-if ( json ) {
-  console.log(JSON.stringify(json))
+const json = parser.parseString(
+  "2017-03-13T01:00:00.146Z,2,127245,204,255,8,fc,f8,ff,7f,ff,7f,ff,ff"
+);
+if (json) {
+  console.log(JSON.stringify(json));
 }
-
 ```
 
 Output:
+
 ```json
 {
-   "description" : "Rudder",
-   "dst" : 255,
-   "prio" : 2,
-   "pgn" : 127245,
-   "fields" : {
-      "Reserved1" : "62",
-      "Direction Order" : 0,
-      "Instance" : 252
-   },
-   "src" : 204,
-   "timestamp" : "2017-03-13T01:00:00.146Z"
+  "description": "Rudder",
+  "dst": 255,
+  "prio": 2,
+  "pgn": 127245,
+  "fields": {
+    "Reserved1": "62",
+    "Direction Order": 0,
+    "Instance": 252
+  },
+  "src": 204,
+  "timestamp": "2017-03-13T01:00:00.146Z"
 }
 ```
 
 ## Parse input from the YDWG-02
 
 ```js
-const json = parser.parseString('16:29:27.082 R 09F8017F 50 C3 B8 13 47 D8 2B C6')
-if ( json ) {
-  console.log(JSON.stringify(json))
+const json = parser.parseString(
+  "16:29:27.082 R 09F8017F 50 C3 B8 13 47 D8 2B C6"
+);
+if (json) {
+  console.log(JSON.stringify(json));
 }
 ```
 
 Output:
+
 ```json
 {
-   "src" : 127,
-   "pgn" : 129025,
-   "description" : "Position, Rapid Update",
-   "timestamp" : "2019-04-10T20:29:27.082Z",
-   "dst" : 255,
-   "prio" : 2,
-   "fields" : {
-      "Latitude" : 33.0875728,
-      "Longitude" : -97.0205113
-   }
+  "src": 127,
+  "pgn": 129025,
+  "description": "Position, Rapid Update",
+  "timestamp": "2019-04-10T20:29:27.082Z",
+  "dst": 255,
+  "prio": 2,
+  "fields": {
+    "Latitude": 33.0875728,
+    "Longitude": -97.0205113
+  }
+}
+```
+
+## Parse input from the MiniPlex-3-N2K
+
+```js
+const json = parser.parseString("$MXPGN,01F801,2801,C1308AC40C5DE343*19");
+if (json) {
+  console.log(JSON.stringify(json));
+}
+```
+
+Output:
+
+```json
+{
+  "src": 1,
+  "pgn": 129025,
+  "description": "Position, Rapid Update",
+  "timestamp": "2019-04-10T20:29:27.082Z",
+  "dst": 255,
+  "prio": 0,
+  "fields": {
+    "Latitude": 33.0875728,
+    "Longitude": -97.0205113
+  }
 }
 ```
 
 ## Generate Actisense format from canboat json
 
 ```js
-const pgnToActisenseSerialFormat = require('./index').pgnToActisenseSerialFormat
+const pgnToActisenseSerialFormat = require("./index")
+  .pgnToActisenseSerialFormat;
 
 const string = pgnToActisenseSerialFormat({
-   "dst" : 255,
-   "prio" : 2,
-   "pgn" : 127245,
-   "fields" : {
-      "Reserved1" : "62",
-      "Direction Order" : 0,
-      "Instance" : 252
-   },
-   "src" : 204,
-})
+  dst: 255,
+  prio: 2,
+  pgn: 127245,
+  fields: {
+    Reserved1: "62",
+    "Direction Order": 0,
+    Instance: 252,
+  },
+  src: 204,
+});
 
-if ( string ) {
-  console.log(string)
+if (string) {
+  console.log(string);
 }
 ```
 
@@ -143,60 +181,58 @@ Output:
 ## Generate iKconvert format from canboat json
 
 ```js
-
-
-const pgnToiKonvertSerialFormat = require('./index').pgnToiKonvertSerialFormat
+const pgnToiKonvertSerialFormat = require("./index").pgnToiKonvertSerialFormat;
 
 const string = pgnToiKonvertSerialFormat({
-   "dst" : 255,
-   "prio" : 2,
-   "pgn" : 127245,
-   "fields" : {
-      "Reserved1" : "62",
-      "Direction Order" : 0,
-      "Instance" : 252
-   },
-   "src" : 204,
-})
+  dst: 255,
+  prio: 2,
+  pgn: 127245,
+  fields: {
+    Reserved1: "62",
+    "Direction Order": 0,
+    Instance: 252,
+  },
+  src: 204,
+});
 
-if ( string ) {
-  console.log(string)
+if (string) {
+  console.log(string);
 }
 ```
 
-Output:  `!PDGY,127245,255,/Pj/f/9///8=`
+Output: `!PDGY,127245,255,/Pj/f/9///8=`
 
 ## Generate YDGW-02 format from canboat json
 
 ```js
-const pgnToYdwgRawFormat = require('./index').pgnToYdwgRawFormat
+const pgnToYdwgRawFormat = require("./index").pgnToYdwgRawFormat;
 
 const array = pgnToYdwgRawFormat({
-  "src":127,
-  "prio":3,
-  "dst":255,
-  "pgn":129029,
-  "fields": {
-    "SID":0,
-    "Date":"2019.02.17",
-    "Time":"16:29:28",
-    "Latitude":33.08757283333333,
-    "Longitude":-97.02051133333333,
-    "Altitude":148.94,
-    "GNSS type":"GPS+GLONASS",
-    "Method":"GNSS fix",
-    "Integrity":"No integrity checking",
-    "Number of SVs":0,
-    "HDOP":0.5,
-    "PDOP":1,
-    "Geoidal Separation":-24,
-    "Reference Stations":0,
-    "list":[{"Reference Station ID":15}]
+  src: 127,
+  prio: 3,
+  dst: 255,
+  pgn: 129029,
+  fields: {
+    SID: 0,
+    Date: "2019.02.17",
+    Time: "16:29:28",
+    Latitude: 33.08757283333333,
+    Longitude: -97.02051133333333,
+    Altitude: 148.94,
+    "GNSS type": "GPS+GLONASS",
+    Method: "GNSS fix",
+    Integrity: "No integrity checking",
+    "Number of SVs": 0,
+    HDOP: 0.5,
+    PDOP: 1,
+    "Geoidal Separation": -24,
+    "Reference Stations": 0,
+    list: [{ "Reference Station ID": 15 }],
   },
-})
+});
 
-if ( array ) {
-  console.log(JSON.stringify(array, null, 2))
+if (array) {
+  console.log(JSON.stringify(array, null, 2));
 }
 ```
 
@@ -219,44 +255,56 @@ Output:
 Before the conversion of the individual fields happens the string needs to be parsed for attributes like priority, pgn, destination, source (collectively the CanId) and the hex or base64 needs to be converted to a Buffer. Use `parseN2kString` for this purpose.
 
 ```javascript
-const { parseN2kString } = require('@canboat/canboatjs')
+const { parseN2kString } = require("@canboat/canboatjs");
 
-const n2kParts1 = parseN2kString('$PCDIN,01F119,00000000,0F,2AAF00D1067414FF*59')
-const matches1 = (n2kParts1 === {
-  data: Buffer.from('2AAF00D1067414FF', 'hex'),
-  dst: 255,
-  format: 'PCDIN',
-  prefix: '$PCDIN',
-  pgn: 127257,
-  prio: 0,
-  src: 15,
-  timer: 0,
-  timestamp: new Date(0),
-})
+const n2kParts1 = parseN2kString(
+  "$PCDIN,01F119,00000000,0F,2AAF00D1067414FF*59"
+);
+const matches1 =
+  n2kParts1 ===
+  {
+    data: Buffer.from("2AAF00D1067414FF", "hex"),
+    dst: 255,
+    format: "PCDIN",
+    prefix: "$PCDIN",
+    pgn: 127257,
+    prio: 0,
+    src: 15,
+    timer: 0,
+    timestamp: new Date(0),
+  };
 
-const n2kParts2 = parseN2kString('16:29:27.082 R 09F8017F 50 C3 B8 13 47 D8 2B C6')
-const today = (new Date()).toISOString().split('T')[0]
-const matches2 = (n2kParts2 === {
-  canId: 0x09F8017F,
-  data: Buffer.from('50C3B81347D82BC6', 'hex'),
-  direction: 'R',
-  dst: 255,
-  format: 'YDRAW',
-  pgn: 129025,
-  prio: 2,
-  src: 127,
-  timestamp: new Date(`${today}T16:29:27.082Z`),
-})
+const n2kParts2 = parseN2kString(
+  "16:29:27.082 R 09F8017F 50 C3 B8 13 47 D8 2B C6"
+);
+const today = new Date().toISOString().split("T")[0];
+const matches2 =
+  n2kParts2 ===
+  {
+    canId: 0x09f8017f,
+    data: Buffer.from("50C3B81347D82BC6", "hex"),
+    direction: "R",
+    dst: 255,
+    format: "YDRAW",
+    pgn: 129025,
+    prio: 2,
+    src: 127,
+    timestamp: new Date(`${today}T16:29:27.082Z`),
+  };
 
-const n2kParts3 = parseN2kString('2016-04-09T16:41:09.078Z,3,127257,17,255,8,00,ff,7f,52,00,21,fe,ff')
-const matches3 = (n2kParts3 === {
-  data: Buffer.from('00ff7f520021feff', 'hex'),
-  dst: 255,
-  len: 8,
-  format: 'Actisense',
-  pgn: 127257,
-  prio: 3,
-  src: 17,
-  timestamp: '2016-04-09T16:41:09.078Z',
-})
+const n2kParts3 = parseN2kString(
+  "2016-04-09T16:41:09.078Z,3,127257,17,255,8,00,ff,7f,52,00,21,fe,ff"
+);
+const matches3 =
+  n2kParts3 ===
+  {
+    data: Buffer.from("00ff7f520021feff", "hex"),
+    dst: 255,
+    len: 8,
+    format: "Actisense",
+    pgn: 127257,
+    prio: 3,
+    src: 17,
+    timestamp: "2016-04-09T16:41:09.078Z",
+  };
 ```

--- a/bin/to-pgn
+++ b/bin/to-pgn
@@ -4,14 +4,14 @@ const argv = require('minimist')(process.argv.slice(2), {
   string: ['format'],
   alias: { h: 'help' }
 })
-const { pgnToActisenseSerialFormat, pgnToiKonvertSerialFormat, pgnToYdgwRawFormat, pgnToPCDIN } = require('../index')
+const { pgnToActisenseSerialFormat, pgnToiKonvertSerialFormat, pgnToYdgwRawFormat, pgnToPCDIN, pgnToMXPGN } = require('../index')
 const { toActisenseSerialFormat } = require('../lib/stringMsg')
 
 if ( argv['help'] ) {
   console.error(`Usage: ${process.argv[0]} [options]
 
 Options:
-  --format <format>   actisense, ikconvert, ydgw, pcdin
+  --format <format>   actisense, ikconvert, ydgw, pcdin, mxpgn
   -h, --help          output usage information`)
   process.exit(1)
 }
@@ -21,7 +21,8 @@ const formatters = {
   actisense: pgnToActisenseSerialFormat,
   ikconvert: pgnToiKonvertSerialFormat,
   ydgw: pgnToYdgwRawFormat,
-  'pcdin': pgnToPCDIN
+  'pcdin': pgnToPCDIN,
+  'mxpgn': pgnToMXPGN
 }
 
 const format = argv['format'] || 'actisense'

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = {
   pgnToiKonvertSerialFormat: require('./lib/toPgn').pgnToiKonvertSerialFormat,
   pgnToYdgwRawFormat: require('./lib/toPgn').pgnToYdgwRawFormat,
   pgnToPCDIN: require('./lib/toPgn').pgnToPCDIN,
+  pgnToMXPGN: require('./lib/toPgn').pgnToMXPGN,
   canbus: require('./lib/canbus'),
   iKonvert: require('./lib/ikonvert'),
   Ydwg02: require('./lib/ydgw02'),

--- a/ios.js
+++ b/ios.js
@@ -17,9 +17,15 @@ global.actisenseToYdgwRawFormat = actisenseToYdgwRawFormat
 global.pgnToYdgwRawFormat = pgnToYdgwRawFormat
 global.pgnToPCDIN = pgnToPCDIN
 global.actisenseToPCDIN = actisenseToPCDIN
-  
+global.pgnToMXPGN = pgnToMXPGN
+global.actisenseToMXPGN = actisenseToMXPGN
+
 global.parsePCDIN = (pcdin) => {
   return parser.parseN2KOver0183(pcdin)
+}
+
+global.parseMXPGN = (mxpgn) => {
+  return parser.parseN2KOver0183(mxpgn)
 }
 
 global.parseHelmSmart = global.parsePCDIN

--- a/lib/stringMsg.js
+++ b/lib/stringMsg.js
@@ -36,6 +36,11 @@ const buildErr = curry((format, msg, input) => ({
   error: new Error(buildErrMsg(msg, input)), format, input,
 }))
 
+function toPaddedHexString(num, len) {
+  str = num.toString(16).toUpperCase();
+  return "0".repeat(len - str.length) + str;
+}
+
 // 2016-02-28T19:57:02.364Z,2,127250,7,255,8,ff,10,3b,ff,7f,ce,f5,fc
 exports.isActisense = input => input.charAt(10) === 'T' && input.charAt(23) === 'Z'
 exports.parseActisense = (input) => {
@@ -82,7 +87,6 @@ exports.encodeYDRAW = ({ data, ...canIdInfo }) => {
 
 // $PCDIN,01F119,00000000,0F,2AAF00D1067414FF*59
 exports.isPCDIN = startsWith('$PCDIN,')
-exports.isN2KOver0183 = exports.isPCDIN
 exports.parsePCDIN = (input) => {
   const [ prefix, pgn, timeHex, src, data ] = input.split(',')
   let timer = parseInt(timeHex, 32)
@@ -98,18 +102,37 @@ exports.parsePCDIN = (input) => {
     { coalesced: true, prefix, timer, timestamp: new Date(timer) },
   )
 }
-exports.parseN2KOver0183 = exports.parsePCDIN
-
-function toPaddedHexString(num, len) {
-  str = num.toString(16).toUpperCase();
-  return "0".repeat(len - str.length) + str;
-}
 
 exports.encodePCDIN = ({ prefix = '$PCDIN', pgn, data, dst = 255}) => {
   const sentence = [ prefix, toPaddedHexString(pgn, 6), '0000180C', hexByte(dst).toUpperCase(), byteString(data, '').toUpperCase()].join(',')
   return sentence + compute0183Checksum(sentence)
 }
 
+// $MXPGN,01F801,2801,C1308AC40C5DE343*19
+exports.isMXPGN = startsWith('$MXPGN,')
+exports.parseMXPGN = (input) => {
+  const [ prefix, pgn, attr_word, data ] = input.split(',')
+
+  const send_prio_len = (parseInt(attr_word.substr(0,2), 16).toString(2)).padStart(8, '0');
+  const addr = (parseInt(attr_word.substr(2,2), 16));
+  const send = parseInt(send_prio_len.substr(0,1), 2);
+  const prio = parseInt(send_prio_len.substr(1,3), 2);
+  const len = parseInt(send_prio_len.substr(4,4), 2);
+  let src, dst;
+  send ? dst = addr: src = addr;
+  
+  return buildMsg(
+    buildCanId(0, parseInt(pgn, 16), 255, parseInt(src, 16)),
+    'MXPGN',
+    Buffer.from(rmChecksum(data), 'hex'),
+    { coalesced: true, prefix },
+  )
+}
+
+exports.encodeMXPGN = ({ prefix = '$MXPGN', pgn, data, dst = 255}) => {
+  const sentence = [ prefix, toPaddedHexString(pgn, 6), '0000180C', hexByte(dst).toUpperCase(), byteString(data, '').toUpperCase()].join(',')
+  return sentence + compute0183Checksum(sentence)
+}
 
 // iKonvert
 // !PDGY,126992,3,2,255,0.563,d2009e45b3b8821d
@@ -180,6 +203,7 @@ exports.parseN2kString = cond([
   [exports.isActisense, exports.parseActisense],
   [exports.isYDRAW, exports.parseYDRAW],
   [exports.isPCDIN, exports.parsePCDIN],
+  [exports.isMXPGN, exports.parseMXPGN],
   [exports.isPDGY, exports.parsePDGY],
   [exports.isCandump1, exports.parseCandump1],
   [exports.isCandump2, exports.parseCandump2],
@@ -193,6 +217,7 @@ exports.isN2KString = cond([
   [exports.isActisense, () => true],
   [exports.isYDRAW, () => true],
   [exports.isPCDIN, () => true],
+  [exports.isMXPGN, () => true],
   [exports.isPDGY, () => true],
   [exports.isCandump1, () => true],
   [exports.isCandump2, () => true],
@@ -200,3 +225,9 @@ exports.isN2KString = cond([
   [exports.isPDGYdebug, () => true],
   [stubTrue, () => false],
 ])
+
+exports.isN2KOver0183 = (msg) => { return exports.isPCDIN(msg) || exports.isMXPGN(msg) }
+
+exports.parseN2KOver0183 = (msg) => { return exports.parsePCDIN(msg) || exports.parseMXPGN(msg) }
+
+

--- a/lib/toPgn.js
+++ b/lib/toPgn.js
@@ -21,7 +21,7 @@ const BitStream = require('bit-buffer').BitStream
 const Int64LE = require('int64-buffer').Int64LE
 const Uint64LE = require('int64-buffer').Uint64LE
 const { getPlainPGNs } = require('./utilities')
-const { encodeActisense, encodeYDRAW, parseActisense, encodePCDIN } = require('./stringMsg')
+const { encodeActisense, encodeYDRAW, parseActisense, encodePCDIN, encodeMXPGN } = require('./stringMsg')
 const { encodeCanId } = require('./canId')
 const { getIndustryCode, getManufacturerCode } = require('./codes')
 const debug = require('debug')('canboatjs:toPgn')
@@ -302,8 +302,13 @@ function pgnToPCDIN(info) {
   return encodePCDIN({ ...info, data: toPgn(info) })
 }
 
+function pgnToMXPGN(info) {
+  return encodeMXPGN({ ...info, data: toPgn(info) })
+}
+
 const actisenseToYdgwRawFormat = _.flow(parseActisense, encodeYDRAW)
 const actisenseToPCDIN = _.flow(parseActisense, encodePCDIN)
+const actisenseToMXPGN = _.flow(parseActisense, encodeMXPGN)
 
 fieldTypeWriters['ASCII text'] = (pgn, field, value, bs) => {
 
@@ -422,3 +427,5 @@ module.exports.actisenseToYdgwRawFormat = actisenseToYdgwRawFormat
 module.exports.pgnToActisenseSerialFormat = pgnToActisenseSerialFormat
 module.exports.pgnToPCDIN = pgnToPCDIN
 module.exports.actisenseToPCDIN = actisenseToPCDIN
+module.exports.pgnToMXPGN = pgnToMXPGN
+module.exports.actisenseToMXPGN = actisenseToMXPGN

--- a/test/mxpgn.js
+++ b/test/mxpgn.js
@@ -1,0 +1,50 @@
+const chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+chai.use(require('chai-json-equal'));
+
+const { FromPgn } = require('../index')
+
+describe('from mxpgn data converts', function () {
+
+  it(`from 129025 converts`, function (done) {
+    var mxpgn = '$MXPGN,01F801,2801,C1308AC40C5DE343*19'
+    var expected = {
+      "pgn":129025,
+      "src":1,
+      "dst":255,
+      "prio":0,
+      "fields":{
+        "Latitude": -99.7576511,
+        "Longitude": 113.8973964,
+      },
+      "description":"Position, Rapid Update"
+    }
+
+    var fromPgn = new FromPgn()
+
+    fromPgn.on('error', (pgn, error) => {
+      console.error(`Error parsing ${pgn.pgn} ${error}`)
+      console.error(error.stack)
+      done(error)
+    })
+
+    fromPgn.on('warning', (pgn, warning) => {
+      done(new Error(`${pgn.pgn} ${warning}`))
+    })
+
+    fromPgn.on('pgn', (pgn) => {
+      try {
+        //console.log(JSON.stringify(pgn))
+        delete pgn.input
+        delete pgn.timestamp
+        pgn.should.jsonEqual(expected)
+        done()
+      } catch ( e ) {
+        done(e)
+      }
+    })
+
+    fromPgn.parseString(mxpgn)
+  })
+})


### PR DESCRIPTION
The Shipmodul MiniPlex-3-N2K models can optionally output $MXPGN sentences, which are NMEA 0183 sentences that contain an N2K PGN number, an attribute field, and the binary data of the PGN, all represented as hexadecimal ASCII field. Adding support for these will make MiniPlex devices more useful in any ecosystem that takes advantage of canboatjs.