### PR TITLE
fix: resolution not handeled properly with latest pgns.json

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -520,17 +520,26 @@ function readField(options, runPostProcessor, pgn, field, bs) {
       if ( field.Resolution && typeof value === 'number' ) {
         var resolution = field.Resolution
 
-        value = (value * resolution)
+        if ( _.isString(resolution) ) {
+          resolution = Number.parseFloat(resolution)
+        }
 
+        value = (value * resolution)
+        
+        let precision = 0;
+        for (let r = resolution; (r > 0.0) && (r < 1.0); r = r * 10.0)
+        {
+          precision++;
+        }
+        
+        value = Number.parseFloat(value.toFixed(precision))
+
+        /*
         if ( resolution === 3.125e-8 ) {
           //yes. hack.
           resolution = "0.0000000001"
         }
-
-        if ( _.isString(resolution) &&
-             resolution.indexOf('.') != -1 ) {
-          value = Number.parseFloat(value.toFixed(resolution.length-2))
-        }
+        */
       }
 
       if (field.EnumValues &&

--- a/test/pgns/127251.js
+++ b/test/pgns/127251.js
@@ -1,4 +1,4 @@
 module.exports = [{
-  "expected": {"timestamp":"2017-04-15T14:57:58.468Z","prio":2,"src":204,"dst":255,"pgn":127251,"description":"Rate of Turn","fields":{"Rate":0.0006910313}},
+  "expected": {"timestamp":"2017-04-15T14:57:58.468Z","prio":2,"src":204,"dst":255,"pgn":127251,"description":"Rate of Turn","fields":{"Rate":0.00069103}},
   "input": "2017-04-15T14:57:58.468Z,2,127251,204,255,8,ff,61,56,00,00,ff,ff,ff"
 }]


### PR DESCRIPTION
The Resolution field used to sometimes be a string, those are now numners in the latest pgns.json

This change makes it work with either format.