### PR TITLE
fix: when reading a WP Name field, read 0xff as ''.

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -636,7 +636,9 @@ fieldTypeReaders['ASCII string starting with length byte'] = (pgn, field, bs) =>
 fieldTypeReaders["String with start/stop byte"] = (pgn, field, bs) => {
   var len
   var first = bs.readUint8()
-  if ( first == 0x02 ) {
+  if ( first == 0xff ) { // no name, stop reading
+    return ''
+  } else if ( first == 0x02 ) {
     var buf = new Buffer(255)
     var c
     var idx = 0


### PR DESCRIPTION
This solves https://github.com/canboat/canboatjs/issues/171 by not mistaking '0xff' for 'here's a 255 bytes string coming', but treat it as empty (which canboat seems to do as well).