### PR TITLE
Fix: Shipmodul MXPGN hex parsing. 

### DIFF
--- a/lib/stringMsg.js
+++ b/lib/stringMsg.js
@@ -112,7 +112,9 @@ exports.encodePCDIN = ({ prefix = '$PCDIN', pgn, data, dst = 255}) => {
 exports.isMXPGN = startsWith('$MXPGN,')
 exports.parseMXPGN = (input) => {
   const [ prefix, pgn, attr_word, data ] = input.split(',')
-
+  
+  var buff = changeEndianness(rmChecksum(data));
+  
   const send_prio_len = (parseInt(attr_word.substr(0,2), 16).toString(2)).padStart(8, '0');
   const addr = (parseInt(attr_word.substr(2,2), 16));
   const send = parseInt(send_prio_len.substr(0,1), 2);
@@ -124,9 +126,19 @@ exports.parseMXPGN = (input) => {
   return buildMsg(
     buildCanId(0, parseInt(pgn, 16), 255, parseInt(src, 16)),
     'MXPGN',
-    Buffer.from(rmChecksum(data), 'hex'),
+    Buffer.from(buff, 'hex'),
     { coalesced: true, prefix },
   )
+}
+
+const changeEndianness = (string) => {
+  const result = [];
+  let len = string.length - 2;
+  while (len >= 0) {
+    result.push(string.substr(len, 2));
+    len -= 2;
+  }
+  return result.join('');
 }
 
 exports.encodeMXPGN = ({ prefix = '$MXPGN', pgn, prio, src, data }) => {


### PR DESCRIPTION
Big- Little- Endian  issue parsing MXPGN / shipmodul 
Shipmodul is sending hex from right to left, SK is expecting from left to right.

see also https://signalk-dev.slack.com/archives/C03F1MKQG/p1633812967355500