### PR TITLE
feature: add support for parsing YDVR files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ This program takes input in the candump format and outputs canboat json format
 
 Example: `candump can0 | candumpanalyzerjs`
 
+## ydvr-file
+
+This program takes input in the [YDVR](https://www.yachtd.com/products/recorder.html) file format and outputs canboat json format
+
+Example: `ydvr-file <file>`
+
 # Usage
 
 ## Installation

--- a/bin/ydvr-file
+++ b/bin/ydvr-file
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const YdvrStream = require('../lib/ydvr.js');
+
+const argv = require('minimist')(process.argv.slice(2), {
+  alias: { h: 'help' },
+});
+
+if (argv['help']) {
+  console.error(`Usage: ${process.argv[0]} file
+
+Options:
+  -h, --help       output usage information`);
+  process.exit(1);
+}
+
+if (argv['_'].length === 0) {
+  console.error('Please specify a file');
+  process.exit(1);
+}
+
+const serial = YdvrStream();
+
+filestream = require('fs').createReadStream(argv['_'][0]);
+filestream.on('error', (err) => {
+  console.error(err.message);
+});
+filestream.on('end', () => {
+  process.exit(0);
+});
+filestream.pipe(serial);

--- a/bin/ydvr-file
+++ b/bin/ydvr-file
@@ -28,4 +28,6 @@ filestream.on('error', (err) => {
 filestream.on('end', () => {
   process.exit(0);
 });
-filestream.pipe(serial);
+filestream.pipe(serial).on("data", (chunk) => {
+  console.log(JSON.stringify(chunk));
+});

--- a/lib/ydvr.js
+++ b/lib/ydvr.js
@@ -1,0 +1,194 @@
+const BitStream = require('bit-buffer').BitStream;
+const Transform = require('stream').Transform;
+const FromPgn = require('./fromPgn').Parser
+const parseCanId = require('./canId').parseCanId;
+
+// https://www.yachtd.com/downloads/ydvr04.pdf Appendix D
+var sequencePgns = new Set([
+  65240,
+  126208,
+  126464,
+  126720,
+  126983,
+  126984,
+  126985,
+  126986,
+  126987,
+  126988,
+  126996,
+  126998,
+  127233,
+  127237,
+  127489,
+  127496,
+  127497,
+  127498,
+  127503,
+  127504,
+  127506,
+  127507,
+  127509,
+  127510,
+  127511,
+  127512,
+  127513,
+  127514,
+  128275,
+  128520,
+  129029,
+  129038,
+  129039,
+  129040,
+  129041,
+  129044,
+  129045,
+  129284,
+  129285,
+  129301,
+  129302,
+  129538,
+  129540,
+  129541,
+  129542,
+  129545,
+  129547,
+  129549,
+  129551,
+  129556,
+  129792,
+  129793,
+  129794,
+  129795,
+  129796,
+  129797,
+  129798,
+  129799,
+  129800,
+  129801,
+  129802,
+  129803,
+  129804,
+  129805,
+  129806,
+  129807,
+  129808,
+  129809,
+  129810,
+  130052,
+  130053,
+  130054,
+  130060,
+  130061,
+  130064,
+  130065,
+  130066,
+  130067,
+  130068,
+  130069,
+  130070,
+  130071,
+  130072,
+  130073,
+  130074,
+  130320,
+  130321,
+  130322,
+  130323,
+  130324,
+  130567,
+  130577,
+  130578,
+  130816,
+]);
+
+function YdvrStream() {
+  if (!(this instanceof YdvrStream)) {
+    return new YdvrStream();
+  }
+
+  this.parser = new FromPgn();
+
+  this.parser.on('error', (pgn, error) => {
+    console.error(`Error parsing ${pgn.pgn} ${error}`);
+    console.error(error.stack);
+  });
+
+  this.parser.on('warning', (pgn, error) => {
+    //console.error(`Warning parsing ${pgn.pgn} ${error}`)
+  });
+
+  this.parser.on('pgn', (pgn) => {
+    console.log(JSON.stringify(pgn));
+  });
+
+  Transform.call(this, {
+    objectMode: true,
+  });
+}
+
+require('util').inherits(YdvrStream, Transform);
+
+YdvrStream.prototype.end = function () {
+  // console.log('end');
+};
+
+YdvrStream.prototype.parseNextRecord = function () {
+  if (this.bs.bitsLeft < 6 * 8) {
+    return false;
+  }
+
+  var time = this.bs.readUint16();
+
+  var identifier = this.bs.readUint32();
+  if (identifier === 0xffffffff) {
+    // service record
+    var srData = this.bs.readArrayBuffer(8);
+  } else {
+    const pgn = parseCanId(identifier);
+
+    var bodyLen;
+    if (pgn.pgn == 59904) {
+      bodyLen = 3;
+    } else if (sequencePgns.has(pgn.pgn)) {
+      var seq = this.bs.readUint8();
+      bodyLen = this.bs.readUint8();
+    } else {
+      bodyLen = 8;
+    }
+    var body = this.bs.readArrayBuffer(bodyLen);
+
+    const parsed = this.parser.parsePgnData(
+      { ...pgn, time: new Date(time).toISOString().slice(11, 23) },
+      bodyLen,
+      body,
+      false,
+      undefined
+    );
+    this.push(parsed);
+  }
+
+  return true;
+}
+
+YdvrStream.prototype._transform = function (chunk, encoding, done) {
+  if (this.bs == null) {
+    this.bs = new BitStream(chunk);
+  } else {
+    var remainingBuffer = this.bs.view.buffer.subarray(this.bs.byteIndex);
+    this.bs = new BitStream(Buffer.concat([remainingBuffer, chunk]));
+  }
+  while (true) {
+    var startIndex = this.bs.byteIndex
+    let parsed = false;
+    try {
+      parsed = this.parseNextRecord();
+    } catch (ex) { }
+    if (!parsed) {
+      this.bs.byteIndex = startIndex;
+      break;
+    }
+  }
+  done();
+};
+
+module.exports = YdvrStream

--- a/lib/ydvr.js
+++ b/lib/ydvr.js
@@ -117,9 +117,9 @@ function YdvrStream() {
     //console.error(`Warning parsing ${pgn.pgn} ${error}`)
   });
 
-  this.parser.on('pgn', (pgn) => {
-    console.log(JSON.stringify(pgn));
-  });
+  // this.parser.on('pgn', (pgn) => {
+  //   console.log(JSON.stringify(pgn));
+  // });
 
   Transform.call(this, {
     objectMode: true,

--- a/lib/ydvr.js
+++ b/lib/ydvr.js
@@ -138,6 +138,14 @@ YdvrStream.prototype.parseNextRecord = function () {
   }
 
   var time = this.bs.readUint16();
+  let timeAbsolute;
+  if (this.lastTime != null && time < this.lastTime) {
+    this.timeOffset = (this.timeOffset || 0) + 60000;
+    timeAbsolute = time + timeOffset;
+  } else {
+    timeAbsolute = time;
+  }
+  this.lastTime = time;
 
   var identifier = this.bs.readUint32();
   if (identifier === 0xffffffff) {

--- a/lib/ydvr.js
+++ b/lib/ydvr.js
@@ -172,7 +172,9 @@ YdvrStream.prototype.parseNextRecord = function () {
       false,
       undefined
     );
-    this.push(parsed);
+    if (parsed) {
+      this.push(parsed);
+    }
   }
 
   return true;

--- a/lib/ydvr.js
+++ b/lib/ydvr.js
@@ -160,7 +160,7 @@ YdvrStream.prototype.parseNextRecord = function () {
     const parsed = this.parser.parsePgnData(
       { ...pgn, time: new Date(time).toISOString().slice(11, 23) },
       bodyLen,
-      body,
+      Buffer.from(body),
       false,
       undefined
     );


### PR DESCRIPTION
Extracts NMEA 2000 data from files recorded on YDVR-03/YDVR-04 devices (https://www.yachtd.com/products/recorder.html) and converts it to canboat json format. The YDVR file format is described in https://www.yachtd.com/downloads/ydvr04.pdf Appendix D. 

I tried to follow the style of the `actisense-file` utility. I did not see a test file for `actisense-file` so not sure how you'd like this being tested; but here's a YDVR sample file: [00010110.DAT.zip](https://github.com/canboat/canboatjs/files/10020448/00010110.DAT.zip)