### PR TITLE
Removing 0x00 to clean up B&G 129285.

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -800,7 +800,7 @@ fieldTypeReaders["String with start/stop byte"] = (pgn, field, bs) => {
       var c = bs.readUint8()
       buf.writeUInt8(c, idx)
     }
-    return buf.toString('ascii', 0, idx)
+    return buf.toString('ascii', 0, idx).replace(/\0.*$/g,'')
   }
 }
 


### PR DESCRIPTION
Remove trailing 0x00 bytes from string (which trim doesn't do).