### PR TITLE
fix: setProviderStatus is not defined

### DIFF
--- a/lib/canbus.js
+++ b/lib/canbus.js
@@ -94,6 +94,9 @@ function CanbusStream (options) {
     this.socketCanWriter = null
     var hasWriter = spawn('sh', ['-c', 'which socketcan-writer'])
 
+    const setProviderError = this.setProviderError.bind(this)
+    const setProviderStatus = this.setProviderStatus.bind(this)
+
     hasWriter.on('close', code => {
       if ( code == 0 ) {
         debug('found socketcan-writer, starting...')


### PR DESCRIPTION
Can't use this inside eventhandler, so bind
these explicitly.