### PR TITLE
chore: remove date-fns

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -24,7 +24,6 @@ const BitStream = require('bit-buffer').BitStream
 const BitView = require('bit-buffer').BitView
 const Int64LE = require('int64-buffer').Int64LE
 const Uint64LE = require('int64-buffer').Uint64LE
-const { parse: parseDate } = require('date-fns')
 
 const { getPGNFromCanId } = require('./utilities')
 const { getIndustryName, getManufacturerName } = require('./codes')

--- a/lib/stringMsg.js
+++ b/lib/stringMsg.js
@@ -8,7 +8,6 @@ const {
 const {
   buildCanId, encodeCanIdString, parseCanId, parseCanIdStr,
 } = require('./canId')
-const { parse: parseDate } = require('date-fns')
 
 /**
  * Helper function that helps merge canId fields with format, data, and others.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "dependencies": {
     "@canboat/pgns": "3.x.x",
     "bit-buffer": "0.2.3",
-    "date-fns": "2.0.0-alpha.27",
     "debug": "^4.3.4",
     "dnssd": "^0.4.1",
     "int64-buffer": "^0.1.10",


### PR DESCRIPTION
date-fns is 16 megs and seems unused to me, so remove it.