### PR TITLE
fix: call setProviderXX methods

### DIFF
--- a/lib/canbus.js
+++ b/lib/canbus.js
@@ -54,14 +54,16 @@ function CanbusStream (options) {
   this.options = options
   this.start()
 
+   console.trace()
+   console.log(options.app.ssetProviderStatus)
   this.setProviderStatus = options.app && options.app.setProviderStatus
     ? (msg) => {
-      options.app.setPluginStatus(options.providerId, msg)
+      options.app.setProviderStatus(options.providerId, msg)
     }
   : () => {}
   this.setProviderError = options.app && options.app.setProviderError
     ? (msg) => {
-      options.app.setPluginError(options.providerId, msg)
+      options.app.setProviderError(options.providerId, msg)
     }
   : () => {}
   


### PR DESCRIPTION
Canbus connections are handled as plugins in the server, because here we were calling setPluginXX methods instead of setProviderXX.