### PR TITLE
refactor: optimise object creation & remove spread

### DIFF
--- a/lib/stringMsg.js
+++ b/lib/stringMsg.js
@@ -20,12 +20,14 @@ const {
  * @return {Object}           All canId fields with format and data props added.
  */
 function buildMsg(canIdInfo, format, data, rest = {}) {
-  return {
-    ...canIdInfo,
-    format,
-    data,
-    ...rest,
+  canIdInfo.format = canIdInfo.format ? canIdInfo.format : format
+  canIdInfo.data = canIdInfo.data ? canIdInfo.data : data
+  for (const property in rest) {
+    if (canIdInfo[property] === undefined) {
+      canIdInfo[property] = rest[property]
+    }
   }
+  return canIdInfo
 }
 function buildErrMsg(msg, input) {
   if (input && isString(input)) return `${msg} - ${input}`


### PR DESCRIPTION
This came up during a recent profiling session: there's a hotspot here, using the spread operator to create a new object.

With server processing an n2k file with the server with `"noThrottle": true` for the `simple` stream configuration, multiplexed file playback the baseline throughput was 35k deltas/s and with small change it jumped to 45k deltas/s, so not an insignificant change.

I have not looked into any deeper: does this really need to construct a new object? Or can it just modify the incoming object? All tests pass, but I am really no expert with this codebase, so please have a deeper look.