### PR TITLE
feature: make the NMEA 2000 product serial code unique

### DIFF
--- a/lib/candevice.js
+++ b/lib/candevice.js
@@ -62,7 +62,7 @@ class CanDevice extends EventEmitter {
         "Model ID": "Signal K",
         "Software Version Code": "1.0",
         "Model Version": "canbusjs",
-        "Model Serial Code": "123456",
+        "Model Serial Code": options.uniqueNumber ? options.uniqueNumber.toString() : "000001",
         "Certification Level": 0,
         "Load Equivalency": 1
       }


### PR DESCRIPTION
Use the `uniqueNumber` value as the NMEA 2000 product info model serial code instead of a hard-coded constant. This should allow having multiple Signal K servers on the same NMEA 2000 bus (a common occurrence in my lab setting).