### PR TITLE
Correct GPS date PGN info for GPS lapped weeknr

### DIFF
--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -928,6 +928,10 @@ fieldTypePostProcessors['DATE'] = (field, value) => {
   if ( value >= 0xfffd ) {
     value = undefined
   } else {
+    // Correct if days since epoch is from before 01/01/2024 due to GPS lapped weeknr
+    if (value < 19723) {
+      value = value + 7168
+    }
     var date = new Date((value) * 86400 * 1000)
     //var date = moment.unix(0).add(value+1, 'days').utc().toDate()
     value = `${date.getUTCFullYear()}.${pad2(date.getUTCMonth()+1)}.${pad2(date.getUTCDate())}`


### PR DESCRIPTION
Correct GPS date PGN info if days since epoch is from before 01/01/2024 due to GPS lapped weeknr