### PR TITLE
feature: support little endian $MXPGN

### DIFF
--- a/bin/analyzerjs
+++ b/bin/analyzerjs
@@ -2,7 +2,8 @@
 
 const argv = require('minimist')(process.argv.slice(2), {
   alias: { h: 'help' },
-  boolean: ['n']
+  boolean: ['n'],
+  boolean: ['r']
 })
 
 if ( argv['help'] ) {
@@ -11,6 +12,7 @@ if ( argv['help'] ) {
 Options:
   -c                  don't check for invalid values
   -n                  output null values
+  -r                  parse $MXPGN as little endian
   -h, --help          output usage information`)
   process.exit(1)
 }
@@ -18,6 +20,7 @@ Options:
 const Parser = require('../index').FromPgn
 var parser = new Parser( {
   returnNulls: argv['n'] === true,
+  littleEndianMXPGN: argv['r'] === true,
   checkForInvalidFields: argv['c'] !== true
 })
 

--- a/lib/fromPgn.js
+++ b/lib/fromPgn.js
@@ -454,7 +454,7 @@ class Parser extends EventEmitter {
 
   parseString (pgn_data, cb) {
     try {
-      const { coalesced, data, error, len, ...pgn } = parseN2kString(pgn_data)
+      const { coalesced, data, error, len, ...pgn } = parseN2kString(pgn_data, this.options)
       if (error) {
         cb && cb(error)
         this.emit('error', pgn, error)

--- a/lib/stringMsg.js
+++ b/lib/stringMsg.js
@@ -156,12 +156,22 @@ exports.encodePCDIN = ({ prefix = '$PCDIN', pgn, data, dst = 255}) => {
   return sentence + compute0183Checksum(sentence)
 }
 
+const changeEndianness = (string) => {
+  const result = [];
+  let len = string.length - 2;
+  while (len >= 0) {
+    result.push(string.substr(len, 2));
+    len -= 2;
+  }
+  return result.join('');
+}
+
 // $MXPGN,01F801,2801,C1308AC40C5DE343*19
 exports.isMXPGN = (msg) => {
   const sentence = get0183Sentence(msg)
   return sentence.startsWith('$MXPGN,')
 }
-exports.parseMXPGN = (input) => {
+exports.parseMXPGN = (input, options) => {
   const sentence = get0183Sentence(input)
   const [ prefix, pgn, attr_word, data ] = sentence.split(',')
 
@@ -172,11 +182,18 @@ exports.parseMXPGN = (input) => {
   const len = parseInt(send_prio_len.substr(4,4), 2);
   let src, dst;
   send ? dst = addr: src = addr;
+
+  let reversed
+
+  if ( options && options.littleEndianMXPGN )
+    reversed = changeEndianness(rmChecksum(data))
+  else
+    reversed = data
   
   return buildMsg(
     buildCanId(0, parseInt(pgn, 16), 255, parseInt(src, 16)),
     'MXPGN',
-    Buffer.from(rmChecksum(data), 'hex'),
+    Buffer.from(reversed, 'hex'),
     { coalesced: true, prefix },
   )
 }


### PR DESCRIPTION

To enable this in Signal K, edit ~/.signalk/settings.json, add littleEndianMXPGN to your 0183 connection subOptions :

```
{                                                                       
  "type": "providers/simple",                                           
  "options": {                                                          
    "logging": false,                                                   
    "type": "NMEA0183",                                                 
    "subOptions": {                                                     
      "validateChecksum": true,                                         
      "type": "serial",                                                 
      "device": "/dev/serial/by-id/usb-CustomWare_ShipModul_MiniPlex-Lite_07001844-if00-port0",                                                        
      "baudrate": 57600,                                                
      "providerId": "miniplex",                                         
      "sentenceEvent": "",                                              
      "toStdout": [                                                     
        "nmea0183out"                                                   
      ],
      "littleEndianMXPGN": true
    },                                                                  
    "providerId": "miniplex"                                            
  }
}
```