### PR TITLE
introducing optional Manufacturer code

### DIFF
--- a/lib/candevice.js
+++ b/lib/candevice.js
@@ -45,7 +45,7 @@ class CanDevice extends EventEmitter {
         dst: 255,
         prio:6,        
         "Unique Number": 1263,
-        "Manufacturer Code": 999,
+        "Manufacturer Code": isNaN(options.mfgCode) ? 999 : options.mfgCode,
         "Device Function": 130,      // PC gateway
         "Device Class": 25,          // Inter/Intranetwork Device
         "Device Instance Lower": 0,


### PR DESCRIPTION
to fix incorrect SignalK source identification in B&G Triton2 MFD