### PR TITLE
fix: issues with address claim process

### DIFF
--- a/lib/n2kDevice.js
+++ b/lib/n2kDevice.js
@@ -97,6 +97,8 @@ class N2kDevice extends EventEmitter {
     this.foundConflict = false
     this.heartbeatCounter = 0
     this.devices = {}
+    this.sentAvailable = false
+    this.addressClaimDetectionTime = options.addressClaimDetectionTime !== undefined ? options.addressClaimDetectionTime : 5000
 
     if ( !options.disableDefaultTransmitPGNs ) {
       this.transmitPGNs = _.union(deviceTransmitPGNs, defaultTransmitPGNs)
@@ -244,8 +246,8 @@ function handleISOAddressClaim(device, n2kMsg) {
   } else if(uint64ValueFromOurOwnClaim > uint64ValueFromReceivedClaim) {
     this.foundConflict = true
     increaseOwnAddress(device)    // We have bigger address claim data -> we have to change our address
+    debug(`Address conflict detected!  trying address ${device.address}.`)
     sendAddressClaim(device)
-    debug(`Address conflict detected! Changed our address to ${device.address}.`)
   }
 }
 
@@ -260,7 +262,7 @@ function handleProductInformation(device, n2kMsg) {
   if ( !device.devices[n2kMsg.src] ) {
     device.devices[n2kMsg.src] = {}
   }
-  debug('got production information %j', n2kMsg)
+  debug('got product information %j', n2kMsg)
   device.devices[n2kMsg.src].productInformation = n2kMsg
 }
 
@@ -289,25 +291,31 @@ function sendAddressClaim(device) {
   }
   debug(`Sending address claim ${device.address}`)
   device.sendPGN(device.addressClaim)
-  setTimeout(() => {
-    if ( !device.foundConflict ) {
-      debug('no address conflics, enabling send')
+  device.addressClaimSentAt = Date.now()
+  if ( device.addressClaimChecker ) {
+    clearTimeout(device.addressClaimChecker)
+  }
+  
+  device.addressClaimChecker = setTimeout(() => {
+    //if ( Date.now() - device.addressClaimSentAt > 1000 ) {
+      //device.addressClaimChecker = null
+      debug('claimed address %d', device.address)
       device.cansend = true
-      if ( device.options.app ) {
-        device.options.app.emit('nmea2000OutAvailable')
+      if ( !device.sentAvailable ) {
+        if ( device.options.app ) {
+          device.options.app.emit('nmea2000OutAvailable')
+        }
+        device.emit('nmea2000OutAvailable')
+          device.sentAvailable = true
       }
       sendISORequest(device, 126996)
-      device.heartbeatInterval = setInterval(() => {
-        sendHeartbeat(device)
-      }, 60*1000)
-      /*
-      _.keys(device.devices).forEach((address) => {
-        sendISORequest(device, 126996, undefined, address)
-      })
-      */
-
-    }
-  }, 250)
+      if ( !device.heartbeatInterval ) {
+        device.heartbeatInterval = setInterval(() => {
+          sendHeartbeat(device)
+        }, 60*1000)
+      }
+    //}
+  }, device.addressClaimDetectionTime)
 }
 
 function sendISORequest(device, pgn, src, dst=255) {


### PR DESCRIPTION
wait longer (5 seconds by default) before starting to send out data nmea2000OutAvailable could be sent more than once
multiple hertbeat interval timers could be started