### PR TITLE
Fix junk characters in AIS on Raymarine MFDs

### DIFF
--- a/lib/toPgn.ts
+++ b/lib/toPgn.ts
@@ -516,7 +516,18 @@ fieldTypeWriters['STRING_FIX'] = (pgn, field, value, bs) => {
         }
       }
     }
-
+    if (pgn == 129038 ||
+        pgn == 129039 ||
+        pgn == 129040 ||
+        pgn == 192041 ||
+        pgn == 129794 ||
+        pgn == 129798 ||
+        pgn == 129802 ||
+        pgn == 129809 ||
+        pgn == 129810)
+    {
+        fill = 0x40;
+    }
     if (value === undefined) {
       value = ''
     }


### PR DESCRIPTION
Raymarine Axiom (at least) do not grok AIS strings padded with 0xff and expect padding with 0x40. I do not know if this applies to all STRING_FIX in all NMEA messages; so this is a surgical fix until more information is gathered. 
"It fixes it for me" and probably warrants more data collection.

Other users report the same issue:
https://forum.openmarine.net/showthread.php?tid=4681