### PR TITLE
https://github.com/canboat/canboatjs/issues/387

### DIFF
--- a/lib/ikonvert.ts
+++ b/lib/ikonvert.ts
@@ -215,7 +215,11 @@ iKonvertStream.prototype._transform = function (
     const msg = `NavLink2 error ${parts[2]}: ${parts[3]}`
     console.error(msg)
     //this.setProviderError(msg)
-  }
+  } else if (line.startsWith('!PDGY')) {
+            this.isSetup = true;
+            this.cansend = true;
+    }
+  
 
   if (!this.isSetup) {
     this.debug(line)


### PR DESCRIPTION
ikonvert does not work if device is already initialized.

This fixed my issue but i'm not sure if its the correct fix. 

Related: 
https://github.com/SignalK/signalk-server/issues/2161
https://github.com/canboat/canboatjs/issues/387