### PR TITLE
fix: guard STRING_LAU writer against undefined value for PGN 129041 AtoN Name

### DIFF
--- a/lib/toPgn.ts
+++ b/lib/toPgn.ts
@@ -599,7 +599,7 @@ fieldTypeWriters['String with start/stop byte'] = (pgn, field, value, bs) => {
 }
 
 fieldTypeWriters[RES_STRINGLAU] = (pgn, field, value, bs) => {
-  if (pgn === 129041 && field.Name === 'AtoN Name') {
+  if (pgn === 129041 && field.Name === 'AtoN Name' && value) {
     if (value.length > 18) {
       value = value.substring(0, 18)
     } else {


### PR DESCRIPTION
## Summary

The `STRING_LAU` field writer in `toPgn.ts` crashes with `TypeError: Cannot read properties of undefined (reading 'length')` when invoked with an `undefined` value for PGN 129041 (AIS Aids to Navigation Report).

`writeField` explicitly dispatches to the per-FieldType writer when a value is `undefined`/`null` (lib/toPgn.ts:258-260), and the rest of the STRING_LAU writer correctly guards against undefined at lines 610 and 613. However, the PGN 129041 special case at line 603 (`value.length > 18`) was not guarded and crashes the sender.

## Repro path

Reported via SignalK Discord (MacJL): `signalk-to-nmea2000` plugin's AIS conversion emits PGN 129041 for any vessel with `sensors.ais.class == "ATON"`. In `generateAtoN` ([conversions/ais.js:395](https://github.com/SignalK/signalk-to-nmea2000/blob/master/conversions/ais.js#L395)), `AtoN Name` is populated from `vessel.name`, which is `undefined` when the AtoN target has no name set. canboatjs then crashes in `sendPGN` and SignalK disappears from the N2K bus.

Stack trace from affected user (canboatjs 3.16.3):
```
TypeError: Cannot read properties of undefined (reading 'length')
    at fieldTypeWriters.<computed> [as STRING_LAU] (.../canboatjs/dist/toPgn.js:493:19)
    at writeField (.../canboatjs/dist/toPgn.js:194:46)
    at toPgn (.../canboatjs/dist/toPgn.js:119:9)
    at CanbusStream.sendPGN (.../canboatjs/dist/canbus.js:304:44)
    ...
    at .../signalk-to-nmea2000/index.js:166:17
```

Line 493 of the compiled dist is exactly the `value.length > 18` check on the 129041 AtoN Name branch.

## Fix

Add `&& value` to the PGN 129041 special-case guard, matching the pattern used elsewhere in the same function.
