### PR TITLE
fix: DLE-escape length and checksum bytes in Actisense framing

### DIFF
--- a/lib/actisense-serial.test.ts
+++ b/lib/actisense-serial.test.ts
@@ -1,0 +1,108 @@
+import { composeMessage } from './actisense-serial'
+
+const DLE = 0x10
+const STX = 0x02
+const ETX = 0x03
+const N2K_MSG_SEND = 0x94
+
+// Reference framing parser matching the NGT-1's byte-stuffing protocol.
+// Returns the unescaped payload (command byte + body) extracted from a
+// well-formed DLE/STX...DLE/ETX frame, or null if framing is broken.
+function unframe(bytes: Buffer): Buffer | null {
+  const out: number[] = []
+  let i = 0
+  if (bytes[i++] !== DLE || bytes[i++] !== STX) return null
+  while (i < bytes.length) {
+    const c = bytes[i++]
+    if (c === DLE) {
+      const next = bytes[i++]
+      if (next === ETX) {
+        // checksum is the last unescaped byte before DLE ETX
+        out.pop()
+        return Buffer.from(out)
+      }
+      if (next === DLE) {
+        out.push(DLE)
+        continue
+      }
+      return null // unexpected DLE escape
+    }
+    out.push(c)
+  }
+  return null // never saw DLE ETX
+}
+
+describe('composeMessage DLE escaping', () => {
+  test('payload of exactly 16 bytes escapes the length byte (regression for unescaped len == DLE)', () => {
+    // The 126208 NMEA Command Group Function with two parameters produces
+    // a 10-byte data payload, which becomes a 16-byte framed body
+    // (1 prio + 3 pgn + 1 dst + 1 bytecount + 10 data). The body length
+    // 0x10 collides with the DLE escape byte. Without escaping, the NGT-1
+    // sees `94 10 02 ...` and resets framing on `DLE STX`, losing the
+    // command byte and the rest of the message.
+    const body = Buffer.from([
+      0x02, 0x00, 0xed, 0x01, 0x10, 0x0a, 0x01, 0x0d, 0xf2, 0x01, 0xf8, 0x02,
+      0x01, 0x2a, 0x0d, 0x01
+    ])
+    expect(body.length).toBe(0x10)
+
+    const framed = composeMessage(N2K_MSG_SEND, body, body.length)
+
+    // After the leading DLE STX command, the length byte 0x10 must be
+    // doubled so the receiver doesn't mistake it for a framing escape.
+    expect(framed[0]).toBe(DLE)
+    expect(framed[1]).toBe(STX)
+    expect(framed[2]).toBe(N2K_MSG_SEND)
+    expect(framed[3]).toBe(0x10) // length
+    expect(framed[4]).toBe(0x10) // escape — this is what the old code missed
+  })
+
+  test('payload of exactly 16 bytes round-trips through framing parser', () => {
+    const body = Buffer.from([
+      0x02, 0x00, 0xed, 0x01, 0x10, 0x0a, 0x01, 0x0d, 0xf2, 0x01, 0xf8, 0x02,
+      0x01, 0x2a, 0x0d, 0x01
+    ])
+
+    const framed = composeMessage(N2K_MSG_SEND, body, body.length)
+    const unframed = unframe(framed)
+
+    expect(unframed).not.toBeNull()
+    // unframed = [command, length, ...body]
+    expect(unframed![0]).toBe(N2K_MSG_SEND)
+    expect(unframed![1]).toBe(body.length)
+    expect(unframed!.subarray(2)).toEqual(body)
+  })
+
+  test('checksum byte is escaped when it equals DLE', () => {
+    // Construct a body whose checksum collides with DLE.
+    // checksum = (256 - (command + len + sum(body))) mod 256
+    // For checksum = 0x10, need (command + len + sum(body)) mod 256 == 0xf0.
+    // command 0x94 (148) + len 1 + body[0] = 240  =>  body[0] = 91 (0x5b)
+    const body = Buffer.from([0x5b])
+    const framed = composeMessage(N2K_MSG_SEND, body, body.length)
+
+    // Trailing pattern: ... <escaped checksum> DLE ETX
+    // With escape: [..., 0x10, 0x10, 0x10, 0x03]
+    const tail = Array.from(framed.slice(framed.length - 4))
+    expect(tail).toEqual([0x10, 0x10, 0x10, 0x03])
+
+    // Round-trip parse must still yield the original body and the
+    // computed checksum byte (0x10) without confusing the parser.
+    const unframed = unframe(framed)
+    expect(unframed).not.toBeNull()
+    expect(unframed![0]).toBe(N2K_MSG_SEND)
+    expect(unframed![1]).toBe(body.length)
+    expect(unframed!.subarray(2)).toEqual(body)
+  })
+
+  test('payload with embedded DLE byte is escaped (existing behavior, regression guard)', () => {
+    const body = Buffer.from([0x01, DLE, 0x02])
+    const framed = composeMessage(N2K_MSG_SEND, body, body.length)
+    const unframed = unframe(framed)
+
+    expect(unframed).not.toBeNull()
+    expect(unframed![0]).toBe(N2K_MSG_SEND)
+    expect(unframed![1]).toBe(body.length)
+    expect(unframed!.subarray(2)).toEqual(body)
+  })
+})

--- a/lib/actisense-serial.ts
+++ b/lib/actisense-serial.ts
@@ -34,13 +34,17 @@ const ESC = 0x1b /* Escape */
 
 /* Actisense message structure is:
 
-   DLE STX <command> <len> [<data> ...]  <checksum> DLE ETX
+   DLE STX <command> <len> [<data> ...] <checksum> DLE ETX
 
-   <command> is a byte from the list below.
-   In <data> any DLE characters are double escaped (DLE DLE).
-   <len> encodes the unescaped length.
-   <checksum> is such that the sum of all unescaped data bytes plus the command
-              byte plus the length adds up to zero, modulo 256.
+   Byte stuffing: any DLE (0x10) byte appearing in <len>, <data>, or
+   <checksum> is duplicated on the wire (written as DLE DLE). The
+   leading DLE STX and trailing DLE ETX are framing markers and are
+   never stuffed.
+   <command> is a byte from the list below and is written as-is.
+   <len> is the payload length in bytes — the number of <data> bytes
+         before byte stuffing.
+   <checksum> is chosen so command + len + all unescaped <data> bytes +
+              checksum is 0 modulo 256.
 */
 
 const N2K_MSG_RECEIVED = 0x93 /* Receive standard N2K message */
@@ -525,17 +529,18 @@ function binToActisense(buffer: Buffer) {
   )
 }
 
-function composeMessage(command: number, buffer: Buffer, len: number) {
+export function composeMessage(command: number, buffer: Buffer, len: number) {
   const outBuf = Buffer.alloc(500)
   const out = new BitStream(outBuf)
 
   out.writeUint8(DLE)
   out.writeUint8(STX)
   out.writeUint8(command)
-
-  const lenPos = out.byteIndex
-  out.writeUint8(0) //length. will update later
-  let crc = command
+  out.writeUint8(len)
+  if (len == DLE) {
+    out.writeUint8(DLE)
+  }
+  let crc = addUInt8(command, len)
 
   for (let i = 0; i < len; i++) {
     const c = buffer.readUInt8(i)
@@ -546,15 +551,13 @@ function composeMessage(command: number, buffer: Buffer, len: number) {
     crc = addUInt8(crc, c)
   }
 
-  crc = addUInt8(crc, len)
-
-  out.writeUint8(256 - crc)
+  const checksum = (256 - crc) & 0xff
+  if (checksum == DLE) {
+    out.writeUint8(DLE)
+  }
+  out.writeUint8(checksum)
   out.writeUint8(DLE)
   out.writeUint8(ETX)
-
-  out.view.buffer.writeUInt8(len, lenPos)
-
-  //that.debug(`command ${out.view.buffer[2]} ${lenPos} ${len} ${out.view.buffer[lenPos]} ${out.view.buffer.length} ${out.byteIndex}`)
 
   return out.view.buffer.slice(0, out.byteIndex)
 }


### PR DESCRIPTION
`composeMessage` in `lib/actisense-serial.ts` did not byte-stuff `<len>` or
`<checksum>` when those bytes equalled DLE (`0x10`), causing the NGT-1 to
silently discard any outbound message whose framed body length was exactly
16 bytes (e.g. a 2-parameter PGN 126208 Command) or whose checksum
collided with DLE. See the issue for full analysis, wire trace, and a
side-by-side comparison with the canboat C tool's behavior.

### Change

- Restructure `composeMessage` to write `<len>` up front and DLE-escape it
  if it equals `0x10`, mirroring `actisense-serial.c:475-504` from canboat.
- DLE-escape the checksum byte under the same condition.
- Update the framing comment so it accurately describes which bytes are
  byte-stuffed.

### Tests

New `lib/actisense-serial.test.ts` covers four cases:

1. Length byte is escaped when `len == DLE` (the headline regression).
2. A 16-byte payload round-trips through a reference framing parser.
3. Checksum byte is escaped when checksum equals DLE.
4. Existing data-byte escape still works (regression guard).

3 of the 4 fail against the previous implementation; all pass with the
fix. `npm test` and `npm run ci-lint` are clean.

### Reviewer notes

- `composeMessage` is now `export`ed so the test can import it. It's a
  pure function with no state — the surface change is harmless, but happy
  to keep it private and test through `ActisenseStream` instead if you'd
  prefer.
- No behavior change for any payload that doesn't trigger the collision,
  so existing consumers are unaffected.

Fixes #411
