### PR TITLE
fix: surface native canSocket load error instead of swallowing it

### DIFF
--- a/lib/canSocket.ts
+++ b/lib/canSocket.ts
@@ -33,14 +33,17 @@ let native: {
   openCanSocketNonBlock: (ifname: string) => number
   writeCanFrame: (fd: number, buffer: Buffer) => number
 }
+let nativeLoadError: Error | undefined
 try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   native = require('../build/Release/canSocket.node')
-} catch (_e) {
+} catch (releaseErr) {
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     native = require('../build/Debug/canSocket.node')
-  } catch (_e) {}
+  } catch (_debugErr) {
+    nativeLoadError = releaseErr as Error
+  }
 }
 
 export interface CanMessage {
@@ -63,7 +66,8 @@ export class CanChannel extends EventEmitter {
   constructor(ifname: string) {
     super()
     if (native === undefined) {
-      throw new Error('Failed to load native canSocket module')
+      const detail = nativeLoadError ? `: ${nativeLoadError.message}` : ''
+      throw new Error(`Failed to load native canSocket module${detail}`)
     }
     this.readFd = native.openCanSocket(ifname)
     try {


### PR DESCRIPTION
## Summary

When the native `canSocket.node` addon fails to load at runtime, the current code silently discards the root cause and users see only a generic `Failed to load native canSocket module` message with no way to diagnose *why* the load failed.

Reported downstream: SignalK Discord users on the v2.25 alpine Docker image (`signalk/signalk-server:*-alpine`) hit this — canbus stays silent, no frames emitted. Same canboatjs version on the `24.04` image works fine. Without the underlying `require()` error surfaced, it's impossible to tell whether the `.node` file is missing (node-gyp failed), there's a musl/glibc ABI mismatch, or a missing runtime dep like `libstdc++`.

## Fix

Stash the `Release/canSocket.node` load error in `nativeLoadError` and include its message in the `CanChannel` constructor's thrown error. No behavior change when the addon loads successfully; only the failure-path error message gains detail.

Before:
```
Failed to load native canSocket module
```

After (example — whatever the real dlopen error was):
```
Failed to load native canSocket module: Error: Error loading shared library libstdc++.so.6: No such file or directory (needed by .../build/Release/canSocket.node)
```
