### PR TITLE
fix: stop disabling CAN_RAW_LOOPBACK on the write socket

### DIFF
--- a/native/canSocket.cpp
+++ b/native/canSocket.cpp
@@ -62,16 +62,13 @@ static Napi::Value OpenCanSocketImpl(const Napi::CallbackInfo& info, bool nonblo
       return env.Undefined();
     }
 
-    // Disable local loopback — frames we send should not be echoed back
-    // to the read socket as if they came from the bus.
-    int loopback = 0;
-    if (setsockopt(fd, SOL_CAN_RAW, CAN_RAW_LOOPBACK, &loopback, sizeof(loopback)) < 0) {
-      std::string err =
-          std::string("setsockopt(CAN_RAW_LOOPBACK) for '") + ifname + "': " + strerror(errno);
-      close(fd);
-      Napi::Error::New(env, err).ThrowAsJavaScriptException();
-      return env.Undefined();
-    }
+    // NOTE: CAN_RAW_LOOPBACK is left at its default (enabled). On virtual CAN
+    // (vcan) interfaces the kernel uses loopback to distribute frames between
+    // sockets bound to the same interface — disabling it here would cause
+    // write() to succeed silently while no other socket (including candump or
+    // other processes on the bus) ever sees the frame. The empty CAN_RAW_FILTER
+    // above already prevents unwanted frames from reaching this socket's
+    // receive queue, so loopback has no effect on read behavior.
 
     if (fcntl(fd, F_SETFL, O_NONBLOCK) < 0) {
       std::string err =


### PR DESCRIPTION
## Summary

Regression introduced in #407 (3.16.2). The write-only CAN socket sets `CAN_RAW_LOOPBACK=0`, which silently breaks frame delivery on **virtual CAN (vcan)** interfaces: `write()` returns success, the `TX packets`/`TX bytes` counters on `vcan0` increase, but no other socket — including `candump`, plugins, or any peer on the bus — ever sees the frame.

Reported by MacJL on the SignalK Discord. Symptom: `signalk-server` v2.25.0 stops emitting N2K frames on virtual CAN test setups. His diagnosis traced it to `native/canSocket.cpp` and he verified that removing the `setsockopt(CAN_RAW_LOOPBACK, 0)` call restores frame delivery.

## Root cause

On Linux, `CAN_RAW_LOOPBACK` is the kernel's mechanism for distributing frames between sockets bound to the same interface:

> The local loopback is enabled by default to reproduce traffic as it would be "on the wire" also in the local host.
> — [Linux kernel CAN documentation](https://www.kernel.org/doc/html/latest/networking/can.html)

On vcan, this is the *only* distribution mechanism — vcan has no hardware to physically reflect frames back, so disabling loopback on the sending socket means no other socket on the bus receives the frame.

My original comment in #407 claimed loopback needed to be disabled "so frames we send aren't echoed back to the read socket as if they came from the bus." That reasoning was wrong for two reasons:

1. `CAN_RAW_LOOPBACK` is set on the *write* socket in this code path, but the kernel uses it to decide whether to deliver the frame to *other* sockets (not to gate what the sending socket's own receive queue gets).
2. This socket already has an empty `CAN_RAW_FILTER`, so it receives no frames regardless of loopback state — the concern was moot from the start.

## Fix

Remove the `setsockopt(CAN_RAW_LOOPBACK, 0)` call; leave loopback at the kernel's default (enabled). The comment is replaced with a note explaining *why* loopback is deliberately not disabled, so future readers don't re-introduce this bug.

## Testing

- `npm run build` — clean
- `node-gyp rebuild` — clean
- `npm run test` — 188 passing, 4 pending (same as master)
- Manual confirmation: MacJL reports frames visible in `candump vcan0` after applying this change
