### PR TITLE
fix: use shutdown() to unblock CAN socket read on process.exit()

### DIFF
--- a/lib/canSocket.ts
+++ b/lib/canSocket.ts
@@ -20,7 +20,7 @@
  */
 
 import { EventEmitter } from 'events'
-import { createReadStream, close as fsClose } from 'fs'
+import { createReadStream, closeSync } from 'fs'
 import { ReadStream } from 'fs'
 
 const CAN_EFF_FLAG = 0x80000000
@@ -32,6 +32,7 @@ let native: {
   openCanSocket: (ifname: string) => number
   openCanSocketNonBlock: (ifname: string) => number
   writeCanFrame: (fd: number, buffer: Buffer) => number
+  shutdownCanSocket: (fd: number) => number
 }
 try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -59,6 +60,7 @@ export class CanChannel extends EventEmitter {
   private writeFd: number
   private remainder: Buffer = Buffer.alloc(0)
   private stopped: boolean = false
+  private exitHandler: (() => void) | null = null
 
   constructor(ifname: string) {
     super()
@@ -69,9 +71,15 @@ export class CanChannel extends EventEmitter {
     try {
       this.writeFd = native.openCanSocketNonBlock(ifname)
     } catch (e) {
-      fsClose(this.readFd, () => {})
+      closeSync(this.readFd)
       throw e
     }
+
+    // Ensure the blocking read fd is closed synchronously on process exit
+    // so the threadpool worker blocked in read() is unblocked and the
+    // process can actually terminate.
+    this.exitHandler = () => this.stop()
+    process.on('exit', this.exitHandler)
   }
 
   start(): void {
@@ -114,13 +122,31 @@ export class CanChannel extends EventEmitter {
   }
 
   stop(): void {
+    if (this.stopped) {
+      return
+    }
     this.stopped = true
+    if (this.exitHandler) {
+      process.removeListener('exit', this.exitHandler)
+      this.exitHandler = null
+    }
     if (this.readStream) {
       this.readStream.destroy()
       this.readStream = null
     }
-    fsClose(this.readFd, () => {})
-    fsClose(this.writeFd, () => {})
+    // shutdown() the read socket first so any threadpool worker blocked
+    // in read() is immediately unblocked (returns ENOTCONN). On Linux,
+    // close() alone does NOT interrupt a read() blocked on the same fd
+    // in another thread — the worker would hang forever.
+    try {
+      native.shutdownCanSocket(this.readFd)
+    } catch (_e) {}
+    try {
+      closeSync(this.readFd)
+    } catch (_e) {}
+    try {
+      closeSync(this.writeFd)
+    } catch (_e) {}
   }
 
   send(msg: { id: number; ext?: boolean; data: Buffer }): void {

--- a/native/canSocket.cpp
+++ b/native/canSocket.cpp
@@ -114,10 +114,26 @@ Napi::Value WriteCanFrame(const Napi::CallbackInfo& info) {
   return Napi::Number::New(env, static_cast<int>(written));
 }
 
+Napi::Value ShutdownCanSocket(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() < 1 || !info[0].IsNumber()) {
+    Napi::TypeError::New(env, "shutdownCanSocket(fd) expected")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  int fd = info[0].As<Napi::Number>().Int32Value();
+  int rc = shutdown(fd, SHUT_RDWR);
+
+  return Napi::Number::New(env, rc < 0 ? -errno : 0);
+}
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("openCanSocket", Napi::Function::New(env, OpenCanSocket));
   exports.Set("openCanSocketNonBlock", Napi::Function::New(env, OpenCanSocketNonBlock));
   exports.Set("writeCanFrame", Napi::Function::New(env, WriteCanFrame));
+  exports.Set("shutdownCanSocket", Napi::Function::New(env, ShutdownCanSocket));
   return exports;
 }
 


### PR DESCRIPTION
When process.exit() is called while a CanChannel is active, the process hangs indefinitely. The root cause is a deadlock between the libuv threadpool and the blocked CAN socket read:

1. fs.createReadStream uses libuv's threadpool-based uv_fs_read to read from the blocking CAN socket fd.
2. A threadpool worker is blocked in read(readFd), waiting for CAN frames.
3. On Linux, close() on an fd does NOT interrupt a read() blocked on that fd in another thread. The threadpool worker remains stuck forever.
4. process.exit() tries to join all threadpool workers before terminating, but the blocked worker never returns -- the process hangs.

strace of the hung process confirms this. After the restart HTTP handler runs and shutdown begins, fds are closed and worker threads are signaled, but the main thread gets stuck trying to join a threadpool worker:

  write(1, "stopping CanChannel...", ...)     -- stop() is called
  close(30)                               = 0 -- closeSync(readFd) succeeds
  close(31)                               = 0 -- closeSync(writeFd) succeeds
  write(1, "now stopped\n", 12)           = 12 -- stop() returns
  write(26, "\1\0\0\0\0\0\0\0", 8)       = 8  -- eventfd wake
  ...
  close(5)                                = 0
  close(6)                                = 0
  futex(0x63b468c, FUTEX_WAKE_PRIVATE, 1) = 1 -- wake workers
  futex(0x63b4628, FUTEX_WAKE_PRIVATE, 1) = 0
  futex(..., FUTEX_WAIT_BITSET, 55, NULL, ...) -- HUNG: joining worker
  futex(..., FUTEX_WAIT_BITSET, 56, NULL, ...  -- blocked forever

Despite close(30) succeeding, the threadpool worker's read(30) was already in-flight in kernel space. On Linux, close() does not deliver any signal or error to another thread's blocked read() on the same fd.

The fix uses shutdown(fd, SHUT_RDWR) before close(). For sockets (which CAN fds are -- PF_CAN/SOCK_RAW), shutdown() causes any blocked read() to return immediately with ENOTCONN, freeing the threadpool worker:

- Add shutdownCanSocket(fd) to the native addon (canSocket.cpp) that calls shutdown(fd, SHUT_RDWR).
- Call shutdownCanSocket(readFd) in stop() before closeSync() so the threadpool worker is unblocked before the fd is closed.
- Register a process 'exit' handler to call stop() if process.exit() is called without an explicit stop().
- Guard stop() against double-close.