### PR TITLE
fix: replace blocking-read threadpool design with uv_poll_t-based reads

### DIFF
--- a/lib/canSocket.ts
+++ b/lib/canSocket.ts
@@ -1,39 +1,44 @@
 /**
- * Minimal CAN socket wrapper using fs streams instead of uv_poll_t.
+ * Minimal CAN socket wrapper using uv_poll_t-based reads.
  *
- * The native addon (native/canSocket.cpp) opens a PF_CAN socket, binds it
- * to the interface, and returns the raw fd in blocking mode.
+ * The native addon (native/canSocket.cpp) opens PF_CAN sockets in non-blocking
+ * mode and exposes a CanPoller class that registers a uv_poll_t watcher on the
+ * read fd. When frames are readable, the watcher invokes a JS callback that
+ * drains all available frames via a non-blocking native read. Writes also use
+ * a non-blocking native write so neither direction ever occupies a libuv
+ * threadpool worker — this keeps the threadpool free for fs operations and
+ * lets process.exit() terminate cleanly without hanging on a blocked syscall.
  *
- * Node.js's net.Socket cannot wrap CAN fds (uv_guess_handle returns
- * UV_UNKNOWN_HANDLE). Instead we use fs.createReadStream which uses libuv's
- * threadpool-based uv_fs_read — works on any fd, never stalls, and does not
- * use uv_poll_t.
- *
- * Reads and writes use separate CAN sockets bound to the same interface.
- * The read socket is blocking (for threadpool reads), the write socket is
- * O_NONBLOCK (to avoid stalling when the CAN bus has no listeners).
- * Separate fds prevent writeCanFrame from toggling O_NONBLOCK on the read
- * fd, which caused spurious ReadStream errors and reconnect cycles.
+ * Reads and writes use separate CAN sockets bound to the same interface:
+ * the read socket has the default (full) RX filter, the write socket has an
+ * empty RX filter so the kernel doesn't queue frames into a buffer nobody
+ * reads.
  *
  * Copyright 2025 Signal K contributors
  * Licensed under the Apache License, Version 2.0
  */
 
 import { EventEmitter } from 'events'
-import { createReadStream, closeSync } from 'fs'
-import { ReadStream } from 'fs'
+import { closeSync } from 'fs'
 
 const CAN_EFF_FLAG = 0x80000000
 const CAN_EFF_MASK = 0x1fffffff
 const CAN_FRAME_SIZE = 16 // sizeof(struct can_frame)
 const CAN_DATA_OFFSET = 8
 
-let native: {
-  openCanSocket: (ifname: string) => number
-  openCanSocketNonBlock: (ifname: string) => number
-  writeCanFrame: (fd: number, buffer: Buffer) => number
-  shutdownCanSocket: (fd: number) => number
+interface CanPollerHandle {
+  close(): void
 }
+
+interface NativeBindings {
+  openCanReadSocket: (ifname: string) => number
+  openCanWriteSocket: (ifname: string) => number
+  writeCanFrame: (fd: number, buffer: Buffer) => number
+  readCanFrames: (fd: number) => Buffer[]
+  CanPoller: new (fd: number, callback: () => void) => CanPollerHandle
+}
+
+let native: NativeBindings
 let nativeLoadError: Error | undefined
 try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -58,10 +63,9 @@ export interface CanMessage {
  * start(), stop(), send(), removeAllListeners().
  */
 export class CanChannel extends EventEmitter {
-  private readStream: ReadStream | null = null
   private readFd: number
   private writeFd: number
-  private remainder: Buffer = Buffer.alloc(0)
+  private poller: CanPollerHandle | null = null
   private stopped: boolean = false
   private exitHandler: (() => void) | null = null
 
@@ -71,58 +75,53 @@ export class CanChannel extends EventEmitter {
       const detail = nativeLoadError ? `: ${nativeLoadError.message}` : ''
       throw new Error(`Failed to load native canSocket module${detail}`)
     }
-    this.readFd = native.openCanSocket(ifname)
+    this.readFd = native.openCanReadSocket(ifname)
     try {
-      this.writeFd = native.openCanSocketNonBlock(ifname)
+      this.writeFd = native.openCanWriteSocket(ifname)
     } catch (e) {
       closeSync(this.readFd)
       throw e
     }
 
-    // Ensure the blocking read fd is closed synchronously on process exit
-    // so the threadpool worker blocked in read() is unblocked and the
-    // process can actually terminate.
+    // Defensive: if the process exits without an explicit stop(), the
+    // CanPoller's uv_poll_t handle will keep the libuv loop alive and
+    // process.exit() may hesitate. Clean up on 'exit' as a safety net.
     this.exitHandler = () => this.stop()
     process.on('exit', this.exitHandler)
   }
 
   start(): void {
     this.stopped = false
-    this.readStream = createReadStream('', {
-      fd: this.readFd,
-      autoClose: false,
-      highWaterMark: CAN_FRAME_SIZE * 64
-    })
+    this.poller = new native.CanPoller(this.readFd, () => this.onReadable())
+  }
 
-    this.readStream.on('data', (chunk: Buffer) => {
-      this.remainder = Buffer.concat([this.remainder, chunk])
+  private onReadable(): void {
+    if (this.stopped) {
+      return
+    }
 
-      while (this.remainder.length >= CAN_FRAME_SIZE) {
-        const frame = this.remainder.subarray(0, CAN_FRAME_SIZE)
-        this.remainder = this.remainder.subarray(CAN_FRAME_SIZE)
-
-        const rawId = frame.readUInt32LE(0)
-        const id = rawId & CAN_EFF_MASK
-        const dlc = frame[4]
-        const data = Buffer.from(
-          frame.subarray(CAN_DATA_OFFSET, CAN_DATA_OFFSET + dlc)
-        )
-
-        this.emit('onMessage', { id, data } as CanMessage)
-      }
-    })
-
-    this.readStream.on('error', (err: Error) => {
+    let frames: Buffer[]
+    try {
+      frames = native.readCanFrames(this.readFd)
+    } catch (err) {
       if (!this.stopped) {
-        this.emit('onStopped', err.message)
+        this.emit('onStopped', (err as Error).message)
       }
-    })
+      return
+    }
 
-    this.readStream.on('close', () => {
-      if (!this.stopped) {
-        this.emit('onStopped', 'closed')
+    for (const frame of frames) {
+      if (frame.length < CAN_FRAME_SIZE) {
+        continue
       }
-    })
+      const rawId = frame.readUInt32LE(0)
+      const id = rawId & CAN_EFF_MASK
+      const dlc = frame[4]
+      const data = Buffer.from(
+        frame.subarray(CAN_DATA_OFFSET, CAN_DATA_OFFSET + dlc)
+      )
+      this.emit('onMessage', { id, data } as CanMessage)
+    }
   }
 
   stop(): void {
@@ -134,17 +133,10 @@ export class CanChannel extends EventEmitter {
       process.removeListener('exit', this.exitHandler)
       this.exitHandler = null
     }
-    if (this.readStream) {
-      this.readStream.destroy()
-      this.readStream = null
+    if (this.poller) {
+      this.poller.close()
+      this.poller = null
     }
-    // shutdown() the read socket first so any threadpool worker blocked
-    // in read() is immediately unblocked (returns ENOTCONN). On Linux,
-    // close() alone does NOT interrupt a read() blocked on the same fd
-    // in another thread — the worker would hang forever.
-    try {
-      native.shutdownCanSocket(this.readFd)
-    } catch (_e) {}
     try {
       closeSync(this.readFd)
     } catch (_e) {}

--- a/native/canSocket.cpp
+++ b/native/canSocket.cpp
@@ -1,4 +1,5 @@
 #include <napi.h>
+#include <uv.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
@@ -9,33 +10,25 @@
 #include <cstring>
 #include <cerrno>
 
-static Napi::Value OpenCanSocketImpl(const Napi::CallbackInfo& info, bool nonblock) {
-  Napi::Env env = info.Env();
-
-  if (info.Length() < 1 || !info[0].IsString()) {
-    Napi::TypeError::New(env, "Interface name required")
-        .ThrowAsJavaScriptException();
-    return env.Undefined();
-  }
-
-  std::string ifname = info[0].As<Napi::String>().Utf8Value();
-
+// Open a PF_CAN raw socket bound to the given interface in non-blocking mode.
+// Both reads and writes use non-blocking I/O so the libuv threadpool is never
+// occupied by a blocking syscall — this allows process.exit() to terminate
+// cleanly even when no CAN traffic is flowing.
+static int OpenAndBindCanSocket(const std::string& ifname, std::string& err) {
   int fd = socket(PF_CAN, SOCK_RAW, CAN_RAW);
   if (fd < 0) {
-    Napi::Error::New(env, std::string("socket(PF_CAN): ") + strerror(errno))
-        .ThrowAsJavaScriptException();
-    return env.Undefined();
+    err = std::string("socket(PF_CAN): ") + strerror(errno);
+    return -1;
   }
 
   struct ifreq ifr;
   std::memset(&ifr, 0, sizeof(ifr));
   std::strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
   if (ioctl(fd, SIOCGIFINDEX, &ifr) < 0) {
-    std::string err = std::string("ioctl(SIOCGIFINDEX) for '") + ifname +
-                      "': " + strerror(errno);
+    err = std::string("ioctl(SIOCGIFINDEX) for '") + ifname +
+          "': " + strerror(errno);
     close(fd);
-    Napi::Error::New(env, err).ThrowAsJavaScriptException();
-    return env.Undefined();
+    return -1;
   }
 
   struct sockaddr_can addr;
@@ -43,94 +36,223 @@ static Napi::Value OpenCanSocketImpl(const Napi::CallbackInfo& info, bool nonblo
   addr.can_family = AF_CAN;
   addr.can_ifindex = ifr.ifr_ifindex;
   if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
-    std::string err =
-        std::string("bind() to '") + ifname + "': " + strerror(errno);
+    err = std::string("bind() to '") + ifname + "': " + strerror(errno);
     close(fd);
+    return -1;
+  }
+
+  if (fcntl(fd, F_SETFL, O_NONBLOCK) < 0) {
+    err = std::string("fcntl(O_NONBLOCK) for '") + ifname +
+          "': " + strerror(errno);
+    close(fd);
+    return -1;
+  }
+
+  return fd;
+}
+
+Napi::Value OpenCanReadSocket(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "Interface name required")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  std::string ifname = info[0].As<Napi::String>().Utf8Value();
+  std::string err;
+  int fd = OpenAndBindCanSocket(ifname, err);
+  if (fd < 0) {
+    Napi::Error::New(env, err).ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  return Napi::Number::New(env, fd);
+}
+
+Napi::Value OpenCanWriteSocket(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "Interface name required")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  std::string ifname = info[0].As<Napi::String>().Utf8Value();
+  std::string err;
+  int fd = OpenAndBindCanSocket(ifname, err);
+  if (fd < 0) {
     Napi::Error::New(env, err).ThrowAsJavaScriptException();
     return env.Undefined();
   }
 
-  if (nonblock) {
-    // Disable reception — this socket is write-only. An empty filter array
-    // tells the kernel not to deliver any incoming frames, avoiding wasted
-    // copies into a receive buffer nobody reads.
-    if (setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0) < 0) {
-      std::string err =
-          std::string("setsockopt(CAN_RAW_FILTER) for '") + ifname + "': " + strerror(errno);
-      close(fd);
-      Napi::Error::New(env, err).ThrowAsJavaScriptException();
-      return env.Undefined();
-    }
-
-    // NOTE: CAN_RAW_LOOPBACK is left at its default (enabled). On virtual CAN
-    // (vcan) interfaces the kernel uses loopback to distribute frames between
-    // sockets bound to the same interface — disabling it here would cause
-    // write() to succeed silently while no other socket (including candump or
-    // other processes on the bus) ever sees the frame. The empty CAN_RAW_FILTER
-    // above already prevents unwanted frames from reaching this socket's
-    // receive queue, so loopback has no effect on read behavior.
-
-    if (fcntl(fd, F_SETFL, O_NONBLOCK) < 0) {
-      std::string err =
-          std::string("fcntl(O_NONBLOCK) for '") + ifname + "': " + strerror(errno);
-      close(fd);
-      Napi::Error::New(env, err).ThrowAsJavaScriptException();
-      return env.Undefined();
-    }
+  // Disable reception on the write-only socket — empty filter array tells
+  // the kernel not to deliver incoming frames to this socket's receive
+  // buffer, avoiding wasted copies.
+  if (setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0) < 0) {
+    std::string msg = std::string("setsockopt(CAN_RAW_FILTER) for '") +
+                      ifname + "': " + strerror(errno);
+    close(fd);
+    Napi::Error::New(env, msg).ThrowAsJavaScriptException();
+    return env.Undefined();
   }
+
+  // NOTE: CAN_RAW_LOOPBACK is left at its default (enabled). On virtual CAN
+  // (vcan) interfaces the kernel uses loopback to distribute frames between
+  // sockets bound to the same interface — disabling it would cause write()
+  // to succeed silently while no other socket (including candump or peers
+  // on the bus) ever sees the frame.
 
   return Napi::Number::New(env, fd);
 }
 
-Napi::Value OpenCanSocket(const Napi::CallbackInfo& info) {
-  return OpenCanSocketImpl(info, false);
-}
-
-Napi::Value OpenCanSocketNonBlock(const Napi::CallbackInfo& info) {
-  return OpenCanSocketImpl(info, true);
-}
-
 Napi::Value WriteCanFrame(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-
   if (info.Length() < 2 || !info[0].IsNumber() || !info[1].IsBuffer()) {
     Napi::TypeError::New(env, "writeCanFrame(fd, buffer) expected")
         .ThrowAsJavaScriptException();
     return env.Undefined();
   }
-
   int fd = info[0].As<Napi::Number>().Int32Value();
   Napi::Buffer<uint8_t> buf = info[1].As<Napi::Buffer<uint8_t>>();
-
   ssize_t written = write(fd, buf.Data(), buf.Length());
-
   if (written < 0) {
     return Napi::Number::New(env, -errno);
   }
-
   return Napi::Number::New(env, static_cast<int>(written));
 }
 
-Napi::Value ShutdownCanSocket(const Napi::CallbackInfo& info) {
+// Drain all currently-readable frames from the non-blocking fd into an
+// array of Buffers, returned to JS. Returns an empty array if no frames
+// are available (EAGAIN). This is called from the JS-side poll callback
+// when the fd becomes readable.
+Napi::Value ReadCanFrames(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-
   if (info.Length() < 1 || !info[0].IsNumber()) {
-    Napi::TypeError::New(env, "shutdownCanSocket(fd) expected")
+    Napi::TypeError::New(env, "readCanFrames(fd) expected")
         .ThrowAsJavaScriptException();
     return env.Undefined();
   }
-
   int fd = info[0].As<Napi::Number>().Int32Value();
-  int rc = shutdown(fd, SHUT_RDWR);
 
-  return Napi::Number::New(env, rc < 0 ? -errno : 0);
+  Napi::Array out = Napi::Array::New(env);
+  uint32_t idx = 0;
+  uint8_t buf[sizeof(struct can_frame)];
+
+  while (true) {
+    ssize_t n = read(fd, buf, sizeof(buf));
+    if (n < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        break;
+      }
+      Napi::Error::New(env, std::string("read: ") + strerror(errno))
+          .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+    if (n == 0) {
+      break;
+    }
+    out.Set(idx++, Napi::Buffer<uint8_t>::Copy(env, buf, n));
+  }
+
+  return out;
 }
 
+// CanPoller: wraps a uv_poll_t on a CAN read fd, calls a JS callback when
+// frames are readable. Closing the poller is synchronous and prevents any
+// further callbacks; the underlying fd is the caller's responsibility.
+class CanPoller : public Napi::ObjectWrap<CanPoller> {
+ public:
+  static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    Napi::Function func = DefineClass(
+        env, "CanPoller",
+        {InstanceMethod("close", &CanPoller::Close)});
+    exports.Set("CanPoller", func);
+    return exports;
+  }
+
+  CanPoller(const Napi::CallbackInfo& info) : Napi::ObjectWrap<CanPoller>(info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 2 || !info[0].IsNumber() || !info[1].IsFunction()) {
+      Napi::TypeError::New(env, "new CanPoller(fd, callback)")
+          .ThrowAsJavaScriptException();
+      return;
+    }
+    fd_ = info[0].As<Napi::Number>().Int32Value();
+    callback_.Reset(info[1].As<Napi::Function>(), 1);
+    closed_ = false;
+
+    uv_loop_t* loop = nullptr;
+    napi_get_uv_event_loop(env, &loop);
+    poll_ = new uv_poll_t;
+    poll_->data = this;
+    int rc = uv_poll_init(loop, poll_, fd_);
+    if (rc < 0) {
+      delete poll_;
+      poll_ = nullptr;
+      Napi::Error::New(env,
+                       std::string("uv_poll_init: ") + uv_strerror(rc))
+          .ThrowAsJavaScriptException();
+      return;
+    }
+    rc = uv_poll_start(poll_, UV_READABLE, &CanPoller::OnPoll);
+    if (rc < 0) {
+      uv_close(reinterpret_cast<uv_handle_t*>(poll_), &CanPoller::OnClose);
+      poll_ = nullptr;
+      Napi::Error::New(env,
+                       std::string("uv_poll_start: ") + uv_strerror(rc))
+          .ThrowAsJavaScriptException();
+      return;
+    }
+  }
+
+  ~CanPoller() {
+    // poll_ should already be null after Close(); if not, the object was
+    // GC'd without explicit close — schedule a libuv close to clean up.
+    if (poll_ != nullptr && !closed_) {
+      closed_ = true;
+      uv_poll_stop(poll_);
+      uv_close(reinterpret_cast<uv_handle_t*>(poll_), &CanPoller::OnClose);
+      poll_ = nullptr;
+    }
+  }
+
+ private:
+  static void OnPoll(uv_poll_t* handle, int status, int events) {
+    CanPoller* self = static_cast<CanPoller*>(handle->data);
+    if (self->closed_ || status < 0 || !(events & UV_READABLE)) {
+      return;
+    }
+    Napi::Env env = self->callback_.Env();
+    Napi::HandleScope scope(env);
+    self->callback_.Call({});
+  }
+
+  static void OnClose(uv_handle_t* handle) {
+    delete reinterpret_cast<uv_poll_t*>(handle);
+  }
+
+  Napi::Value Close(const Napi::CallbackInfo& info) {
+    if (!closed_ && poll_ != nullptr) {
+      closed_ = true;
+      uv_poll_stop(poll_);
+      uv_close(reinterpret_cast<uv_handle_t*>(poll_), &CanPoller::OnClose);
+      poll_ = nullptr;
+      callback_.Reset();
+    }
+    return info.Env().Undefined();
+  }
+
+  int fd_ = -1;
+  uv_poll_t* poll_ = nullptr;
+  bool closed_ = true;
+  Napi::FunctionReference callback_;
+};
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
-  exports.Set("openCanSocket", Napi::Function::New(env, OpenCanSocket));
-  exports.Set("openCanSocketNonBlock", Napi::Function::New(env, OpenCanSocketNonBlock));
+  exports.Set("openCanReadSocket", Napi::Function::New(env, OpenCanReadSocket));
+  exports.Set("openCanWriteSocket",
+              Napi::Function::New(env, OpenCanWriteSocket));
   exports.Set("writeCanFrame", Napi::Function::New(env, WriteCanFrame));
-  exports.Set("shutdownCanSocket", Napi::Function::New(env, ShutdownCanSocket));
+  exports.Set("readCanFrames", Napi::Function::New(env, ReadCanFrames));
+  CanPoller::Init(env, exports);
   return exports;
 }
 


### PR DESCRIPTION
## Summary

Switches the CAN read path from `fs.createReadStream` (libuv threadpool blocking-read) to a `uv_poll_t`-based watcher with non-blocking native reads. Fixes the exit hang reported in [signalk/signalk-server#2618](https://github.com/SignalK/signalk-server/issues/2618).

## Background

The threadpool-read design from #401 has a fundamental shutdown problem on Linux:

- `fs.createReadStream(fd)` schedules a `uv_fs_read` on the libuv threadpool. The worker calls a blocking `read(fd)` and waits for CAN frames.
- On a quiet bus, that worker is blocked forever in the kernel.
- `process.exit(0)` calls libuv's shutdown which tries to `pthread_join` the worker. The worker is stuck in `read()` and never returns.
- **`close(fd)` does NOT interrupt a `read()` blocked on the same fd in another thread on Linux.** That's POSIX-allowed but Linux-specific behavior.
- **`shutdown(fd, SHUT_RDWR)` does not work either**: `PF_CAN/SOCK_RAW` hooks `.shutdown = sock_no_shutdown` ([raw.c:1049](https://elixir.bootlin.com/linux/v6.12/source/net/can/raw.c#L1049), unchanged through [v6.18](https://elixir.bootlin.com/linux/v6.18/source/net/can/raw.c#L1064)). It returns `EOPNOTSUPP` and the worker stays blocked. PR #415's fix is silently a no-op for this reason.

The strace evidence in #415 is conclusive — the main thread hangs in `futex(...FUTEX_WAIT_BITSET...)` joining a worker that's still in `read()`.

## Fix

Open both read and write sockets `O_NONBLOCK`. Use a `uv_poll_t` watcher on the read fd to detect readability, then drain all available frames in a single non-blocking native read on each callback. Neither direction touches the threadpool, so `process.exit(0)` terminates immediately.

The `uv_poll_t` handle is owned by a small `CanPoller` C++ class exposed via N-API; closing it stops the watcher and releases the libuv handle synchronously.

## Why this also subsumes #401's stated rationale

#401's commit message claimed `uv_poll_t` had a "silent stall failure mode under GC pressure". Looking back at [signalk/signalk-server#1626](https://github.com/SignalK/signalk-server/issues/1626), the symptom was *CAN reading silently stops with signalk-rpi-monitor at low interval*. signalk-rpi-monitor at low interval makes a lot of `fs.read` calls — exactly the workload that exposes threadpool starvation from blocking CAN **writes**. That's what #405 actually fixed (with the non-blocking native `writeCanFrame`). The read-path change in #401 was layered on top without solving the real problem, and brought the exit-hang problem along with it.

## Verification

On vcan0 (kernel 6.12.75):

| Scenario | Master | This PR |
|---|---|---|
| All 188 unit tests | pass | pass |
| Exit with active CanChannel, no traffic | **hangs** (SIGTERM after 5s) | exits immediately |
| 100/200-frame loopback burst | 100%/100% delivery | 100%/100% delivery |
| 1000-frame burst | 222/1000 (kernel `SO_RCVBUF` cap) | 222/1000 (same cap) |

No frame-delivery regression — the kernel receive-buffer cap is identical to master's behavior.

Closes #2618 (signalk-server). Supersedes #415 (correct diagnosis, but the proposed `shutdown()` is a no-op on Linux CAN sockets).
