### PR TITLE
Fixes for yd-simplecan-support: dispatcher, loopback, fan-out, debug init

### DIFF
--- a/examples/signalk-device-emulator/src/index.ts
+++ b/examples/signalk-device-emulator/src/index.ts
@@ -80,33 +80,6 @@ const start = (app: ServerAPI) => {
                       installationDescription1: 'Signal K Device Emulator'
                     })
                   )
-                  emulator = utils.createEmulator(
-                    plugin.id,
-                    {},
-                    new PGN_60928({
-                      manufacturerCode: ManufacturerCode.BepMarine,
-                      deviceFunction: DeviceFunction.SwitchInterface,
-                      deviceClass: DeviceClass.ElectricalDistribution,
-                      deviceInstanceLower: 0,
-                      deviceInstanceUpper: 0,
-                      systemInstance: 0,
-                      industryGroup: IndustryCode.Marine,
-                      arbitraryAddressCapable: YesNo.Yes
-                    }),
-                    new PGN_126996({
-                      nmea2000Version: 1300,
-                      productCode: 100,
-                      modelId: 'mock-czone-device',
-                      softwareVersionCode: '1.0',
-                      modelVersion: '1.0',
-                      modelSerialCode: '123456',
-                      certificationLevel: 0,
-                      loadEquivalency: 1
-                    }),
-                    new PGN_126998({
-                      installationDescription1: 'Signal K Device Emulator'
-                    })
-                  )
                   emulator.onPGN((_pgn: PGN) => { })
                 }
               }

--- a/lib/canbus.ts
+++ b/lib/canbus.ts
@@ -15,12 +15,7 @@
  */
 
 import { DeviceEmulator } from './index'
-import {
-  PGN,
-  PGN_60928,
-  PGN_126998,
-  PGN_126996
-} from '@canboat/ts-pgns'
+import { PGN, PGN_60928, PGN_126998, PGN_126996 } from '@canboat/ts-pgns'
 import { createDebug, byteStringArray } from './utilities'
 import { Transform, EventEmitter } from 'stream'
 import { toPgn } from './toPgn'
@@ -46,6 +41,7 @@ export function CanbusStream(this: any, options: any) {
   this.supportsDeviceCreation = true
   this.sentUtils = false
   this.plainText = false
+  this.devices = {}
   this.options = options
   this.reconnecting = false // Guard flag to prevent concurrent reconnections
   this.stoppingChannel = false // Flag to track intentional stops
@@ -261,6 +257,24 @@ CanbusStream.prototype.connect = function () {
         that.push(data)
       }
     })
+
+    // Fan inbound parsed PGNs out to emulator devices so plugins that
+    // created an emulator via createEmulator() can receive bus traffic
+    // through the emulator's onPGN() callback.
+    if (this.options.app) {
+      const analyzerOutEvent = this.options.analyzerOutEvent || 'N2KAnalyzerOut'
+      const fanOut = (pgn: any) => {
+        const ids = Object.keys(this.devices)
+        for (const id of ids) {
+          const emulator = this.devices[id]
+          if (emulator && typeof emulator.pgnReceived === 'function') {
+            emulator.pgnReceived(pgn)
+          }
+        }
+      }
+      this.options.app.on(analyzerOutEvent, fanOut)
+      this._emulatorFanOut = fanOut
+    }
     this.channel.start()
     this.setProviderStatus('Connected to CAN bus')
     this.candevice = new CanDevice(this, this.options)
@@ -276,8 +290,11 @@ CanbusStream.prototype.connect = function () {
       console.log(`Successfully connected to ${canDevice}`)
     }
 
-    if (this.sentUtils === false && this.options.app.emitPropertyValue ) {
-      this.options.app.emitPropertyValue('canboatjsUtils', { id: this.options.id, utils: this })
+    if (this.sentUtils === false && this.options.app.emitPropertyValue) {
+      this.options.app.emitPropertyValue('canboatjsUtils', {
+        id: this.options.id,
+        utils: this
+      })
       this.sentUtils = true
     }
 
@@ -306,18 +323,32 @@ util.inherits(CanbusStream, Transform)
 
 CanbusStream.prototype.start = function () {}
 
-CanbusStream.prototype.sendPGN = function (msg: any, force: boolean) {
-  return this.sendPGN(msg, this.candevice, force)
-}
-
-CanbusStream.prototype.sendPGN = function (msg: any, candevice: CanDevice, force: boolean) {
+CanbusStream.prototype.sendPGN = function (
+  msg: any,
+  force?: boolean | CanDevice,
+  forceArg?: boolean
+) {
+  // The function accepts two call shapes:
+  //   sendPGN(msg, force?: boolean)            — used by all existing callers
+  //   sendPGN(msg, candevice, force?: boolean) — used by per-emulator path
+  // JavaScript prototypes can only hold one definition for a given property,
+  // so we discriminate on the type of the second argument.
+  let candevice: CanDevice
+  let actualForce: boolean | undefined
+  if (force && typeof force === 'object') {
+    candevice = force
+    actualForce = forceArg
+  } else {
+    candevice = this.candevice
+    actualForce = force as boolean | undefined
+  }
 
   if (this.candevice) {
     if (!this.channel) {
       return
     }
     //if ( !this.candevice.cansend && (_.isString(msg) || msg.pgn !== 59904) ) {
-    if (!candevice.cansend && force !== true) {
+    if (!candevice.cansend && actualForce !== true) {
       //we have not completed address claim yet
       return
     }
@@ -331,9 +362,7 @@ CanbusStream.prototype.sendPGN = function (msg: any, candevice: CanDevice, force
     }
 
     const src =
-      _.isString(msg) === false && msg.forceSrc
-        ? msg.src
-        : candevice.address
+      _.isString(msg) === false && msg.forceSrc ? msg.src : candevice.address
     if (_.isString(msg)) {
       const split = msg.split(',')
       split[3] = src
@@ -476,13 +505,26 @@ CanbusStream.prototype.pipe = function (pipeTo: any) {
   return (CanbusStream as any).super_.prototype.pipe.call(this, pipeTo)
 }
 
-CanbusStream.prototype.createEmulator = function(id:string, options: any, addressClaim: PGN_60928, productInfo: PGN_126996, configInfo: PGN_126998|undefined): DeviceEmulator {
-  const device = new CanbusDeviceEmulator(this, id, options, addressClaim, productInfo, configInfo)
+CanbusStream.prototype.createEmulator = function (
+  id: string,
+  options: any,
+  addressClaim: PGN_60928,
+  productInfo: PGN_126996,
+  configInfo: PGN_126998 | undefined
+): DeviceEmulator {
+  const device = new CanbusDeviceEmulator(
+    this,
+    id,
+    options,
+    addressClaim,
+    productInfo,
+    configInfo
+  )
   this.devices[id] = device
   return device
 }
 
-CanbusStream.prototype.removeEmulator = function(id: string): void {
+CanbusStream.prototype.removeEmulator = function (id: string): void {
   delete this.devices[id]
 }
 
@@ -491,7 +533,14 @@ class CanbusDeviceEmulator extends EventEmitter implements DeviceEmulator {
   private device: CanDevice
   public config: any
 
-  constructor(stream: any, id: string, options: any, addressClaim: PGN_60928, productInfo: PGN_126996, configInfo: PGN_126998|undefined){
+  constructor(
+    stream: any,
+    id: string,
+    options: any,
+    addressClaim: PGN_60928,
+    productInfo: PGN_126996,
+    configInfo: PGN_126998 | undefined
+  ) {
     super()
     this.stream = stream
     this.config = { configPath: stream.options.app?.config?.configPath }
@@ -510,11 +559,11 @@ class CanbusDeviceEmulator extends EventEmitter implements DeviceEmulator {
     this.emit('N2KAnalyzerOut', pgn)
   }
 
-  sendPGN(pgn: PGN, force:boolean): void {
+  sendPGN(pgn: PGN, force: boolean): void {
     this.stream.sendPGN(pgn, this.device, force)
   }
 
-  send(pgn: PGN|string): void {
+  send(pgn: PGN | string): void {
     this.stream.sendPGN(pgn, this.device, false)
   }
 

--- a/lib/simpleCan.ts
+++ b/lib/simpleCan.ts
@@ -37,6 +37,7 @@ export function SimpleCan(
   this.options = options
   this.messageCb = messageCb
   this.plainText = false
+  this.debug = createDebug('canboatjs:n2k-out', options)
 }
 
 SimpleCan.prototype.start = function () {
@@ -46,6 +47,17 @@ SimpleCan.prototype.start = function () {
   if (this.messageCb) {
     this.channel.addListener('onMessage', (msg: any) => {
       const pgn = parseCanId(msg.id)
+
+      // Drop frames the device emitted itself. Without this filter, the
+      // device sees its own announces and heartbeats coming back in via
+      // the socketcan loopback and treats them as real bus traffic.
+      if (
+        this.candevice &&
+        this.candevice.cansend &&
+        pgn.src == this.candevice.address
+      ) {
+        return
+      }
 
       const timestamp = new Date().toISOString()
       if (this.plainText) {

--- a/lib/yddevice.ts
+++ b/lib/yddevice.ts
@@ -16,21 +16,18 @@
 
 import { PGN } from '@canboat/ts-pgns'
 import { N2kDevice } from './n2kDevice'
-import { actisenseToYdgwFullRawFormat } from './toPgn'
 
 export class YdDevice extends N2kDevice {
   yd: any
   app: any
 
-  constructor(yd:any, options: any) {
+  constructor(yd: any, options: any) {
     super(options, 'canboatjs:yddevice')
     this.yd = yd
     this.app = options.app
 
     const analyzerOutEvent = options.analyzerOutEvent || 'N2KAnalyzerOut'
-
     this.app.on(analyzerOutEvent, this.n2kMessage.bind(this))
-
   }
 
   sendPGN(pgn: PGN, src: number | undefined = undefined) {
@@ -39,14 +36,8 @@ export class YdDevice extends N2kDevice {
     const ppgn = pgn as any //FIXME??
     ppgn.ydFullFormat = true
     ppgn.forceSend = true
-    
+
     this.debug('Sending PGN %j', pgn)
     this.yd.sendPGN(pgn, true)
   }
-
-  /*
-  sendActisenseFormat(msg: string) {
-    this.app.emit('ydFullRawOut', actisenseToYdgwFullRawFormat(msg))
-  }
-    */
 }

--- a/lib/ydgw02.ts
+++ b/lib/ydgw02.ts
@@ -26,12 +26,7 @@ import {
 } from './toPgn'
 import { parseCanIdStr } from './canId'
 import { DeviceEmulator } from './index'
-import {
-  PGN,
-  PGN_60928,
-  PGN_126998,
-  PGN_126996
-} from '@canboat/ts-pgns'
+import { PGN, PGN_60928, PGN_126998, PGN_126996 } from '@canboat/ts-pgns'
 import util from 'util'
 
 //const pgnsSent = {}
@@ -51,7 +46,7 @@ export function Ydgw02Stream(this: any, options: any, type: string) {
   this.options = options
   this.outEvent = options.ydgwOutEvent || 'ydwg02-out'
   this.device = undefined
-  this.devices =  {}
+  this.devices = {}
   this.supportsDeviceCreation = true
 
   this.fromPgn = new FromPgn(options)
@@ -124,8 +119,8 @@ Ydgw02Stream.prototype.sendString = function (msg: string, forceSend: boolean) {
   }
 }
 
-Ydgw02Stream.prototype.sendPGN = function (pgn: PGN, force:boolean): void {
-  if (this.cansend() || (pgn as any).forceSend === true) {
+Ydgw02Stream.prototype.sendPGN = function (pgn: PGN, force?: boolean): void {
+  if (this.cansend() || (pgn as any).forceSend === true || force === true) {
     //let now = Date.now()
     //let lastSent = pgnsSent[pgn.pgn]
     let msgs
@@ -198,14 +193,21 @@ Ydgw02Stream.prototype._transform = function (
     return
   }
 
-  if (this.sentAvailable === false && (this.options.createDevice === false || (this.device && this.device.cansend))) {
+  if (
+    this.sentAvailable === false &&
+    (this.options.createDevice === false ||
+      (this.device && this.device.cansend))
+  ) {
     this.sentAvailable = true
-    if ( this.options.createDevice === false ) {
+    if (this.options.createDevice === false) {
       this.debug('emit nmea2000OutAvailable')
       this.options.app.emit('nmea2000OutAvailable')
     }
-    if (this.options.app.emitPropertyValue ) {
-      this.options.app.emitPropertyValue('canboatjsUtils', { id: this.options.id, utils: this })
+    if (this.options.app.emitPropertyValue) {
+      this.options.app.emitPropertyValue('canboatjsUtils', {
+        id: this.options.id,
+        utils: this
+      })
     }
   }
 
@@ -242,8 +244,8 @@ Ydgw02Stream.prototype._transform = function (
       pgn
     )
     Object.values(this.devices).forEach((device: any) => {
-        const yd = device as YDDeviceEmulator
-        yd.pgnReceived(pgn)
+      const yd = device as YDDeviceEmulator
+      yd.pgnReceived(pgn)
     })
   }
 
@@ -252,13 +254,26 @@ Ydgw02Stream.prototype._transform = function (
 
 Ydgw02Stream.prototype.end = function () {}
 
-Ydgw02Stream.prototype.createEmulator = function(id:string, options: any, addressClaim: PGN_60928, productInfo: PGN_126996, configInfo: PGN_126998|undefined): DeviceEmulator {
-  const device = new YDDeviceEmulator(this, id, options, addressClaim, productInfo, configInfo)
+Ydgw02Stream.prototype.createEmulator = function (
+  id: string,
+  options: any,
+  addressClaim: PGN_60928,
+  productInfo: PGN_126996,
+  configInfo: PGN_126998 | undefined
+): DeviceEmulator {
+  const device = new YDDeviceEmulator(
+    this,
+    id,
+    options,
+    addressClaim,
+    productInfo,
+    configInfo
+  )
   this.devices[id] = device
   return device
 }
 
-Ydgw02Stream.prototype.removeEmulator = function(id: string): void {
+Ydgw02Stream.prototype.removeEmulator = function (id: string): void {
   delete this.devices[id]
 }
 
@@ -267,7 +282,14 @@ class YDDeviceEmulator extends EventEmitter implements DeviceEmulator {
   private device: YdDevice
   public config: any
 
-  constructor(stream: any, id: string, options: any, addressClaim: PGN_60928, productInfo: PGN_126996, configInfo: PGN_126998|undefined){
+  constructor(
+    stream: any,
+    id: string,
+    options: any,
+    addressClaim: PGN_60928,
+    productInfo: PGN_126996,
+    configInfo: PGN_126998 | undefined
+  ) {
     super()
     this.stream = stream
     this.config = { configPath: stream.options.app?.config?.configPath }
@@ -286,7 +308,7 @@ class YDDeviceEmulator extends EventEmitter implements DeviceEmulator {
     this.emit('N2KAnalyzerOut', pgn)
   }
 
-  sendPGN(pgn: PGN, force:boolean): void {
+  sendPGN(pgn: PGN, force: boolean): void {
     if (force || this.device.cansend) {
       if (pgn.src !== 254) {
         pgn.src = this.device.address
@@ -299,7 +321,7 @@ class YDDeviceEmulator extends EventEmitter implements DeviceEmulator {
     }
   }
 
-  send(pgn: PGN|string): void {
+  send(pgn: PGN | string): void {
     if (typeof pgn === 'string') {
       const src = this.device.address
 
@@ -312,7 +334,6 @@ class YDDeviceEmulator extends EventEmitter implements DeviceEmulator {
       msgs.forEach((raw) => {
         this.stream.sendString(raw + '\r\n')
       })
-
     } else {
       this.sendPGN(pgn, false)
     }


### PR DESCRIPTION
A few fixes to the device-emulator branch found while wiring it up against the SignalK switching plugin and exercising it on a vcan0 socket.

## Fixes

### `lib/canbus.ts`

- **Collapse the two `sendPGN` definitions.** The prototype had two assignments of `sendPGN` — `(msg, force)` and `(msg, candevice, force)`. JavaScript prototypes don't support overloading, so the second definition silently replaced the first. Existing 2-arg `(msg, force)` callers ended up with their boolean reaching the body as `candevice`, then crashing on `candevice.cansend`. Discriminate on argument type so both call shapes work.
- **Initialise `this.devices = {}` in the constructor.** Currently auto-created on first write, which means `removeEmulator` before `createEmulator` throws.
- **Fan inbound parsed PGNs out to registered emulators.** `Ydgw02Stream` already iterates `Object.values(this.devices).forEach(d => d.pgnReceived(pgn))` in its `_transform`. The canbus side did not, so emulators created via `canbusStream.createEmulator()` never received bus traffic — they were send-only.

### `lib/simpleCan.ts`

- **Initialise `this.debug`.** `sendPGN` references `this.debug.enabled` and `this.debug(str)` but the constructor didn't assign `this.debug`, so first send threw `Cannot read properties of undefined (reading 'enabled')`.
- **Restore the source-loopback filter.** The pre-PR code dropped frames whose `pgn.src == this.candevice.address`. Without it the device sees its own announces and heartbeats coming back through the socketcan loopback path.

### `lib/yddevice.ts`

- Drop the unused `actisenseToYdgwFullRawFormat` import and the commented-out `sendActisenseFormat` method that referenced it. Resolves a CI lint error.

### `lib/ydgw02.ts`

- Make the new `force` parameter on `sendPGN` actually do something — it now bypasses the `cansend()` check the same way `forceSend` does, matching the canbus side. Resolves a CI lint error.

### `examples/signalk-device-emulator/src/index.ts`

- Remove the duplicated `createEmulator` call that was instantiating two `CanDevice`s for the same plugin id.

## Verification

- `npm run build` clean.
- `npm run ci-lint` clean (was 2 errors before).
- `npm test` — 188 passing, 4 pending (unchanged from baseline).
- Manual tests against a local vcan0 (Linux 6.12, vcan kernel module):
  - **Loopback filter**: SimpleCan claims address 100; after `cansend` is set, 0 self-frames are received. ✓
  - **Fan-out**: a `canbus`-backed `DeviceEmulator` registered with `createEmulator` receives PGNs synthesised onto the host's `N2KAnalyzerOut`. ✓
  - **sendPGN dispatcher**: existing 1-arg, 2-arg `(msg, force)`, and new 3-arg `(msg, candevice, force)` callers all complete without crashing. ✓