### PR TITLE
fix(ydgw02): guard sendPGN against undefined this.device

### DIFF
--- a/lib/ydgw02.ts
+++ b/lib/ydgw02.ts
@@ -125,7 +125,15 @@ Ydgw02Stream.prototype.sendPGN = function (pgn: PGN, force?: boolean): void {
     //let lastSent = pgnsSent[pgn.pgn]
     let msgs
     if ((pgn as any).ydFullFormat === true || this.device !== undefined) {
-      if (pgn.src !== 254) {
+      // Only stamp src from this.device when the stream actually owns
+      // a device. ydFullFormat senders (e.g. YdDevice.sendPGN for
+      // Heartbeat / ISO Request responses) already set pgn.src to the
+      // sender's claimed address, so leaving it intact is correct.
+      // Without this guard, every heartbeat from a YdDevice attached
+      // via app event-bus to a Ydgw02Stream that hasn't yet received
+      // an inbound packet (so this.device is still undefined) throws
+      // 'Cannot read properties of undefined (reading address)'.
+      if (pgn.src !== 254 && this.device !== undefined) {
         pgn.src = this.device.address
       }
       msgs = pgnToYdgwFullRawFormat(pgn)


### PR DESCRIPTION
## Summary

`Ydgw02Stream.sendPGN` reads `this.device.address` whenever `pgn.ydFullFormat === true`, but `this.device` is only assigned inside `_transform` once the first inbound packet arrives. A `YdDevice` created via `createDevice: true` and attached to the same app event bus fires Heartbeats every 60 s and responds to ISO Requests independently of the stream's inbound traffic, so on transports that have not yet received data (e.g. a UDP gateway that goes silent, or has not started forwarding yet) every such send threw:

```
TypeError: Cannot read properties of undefined (reading 'address')
    at Ydgw02Stream.sendPGN (.../dist/ydgw02.js:110:39)
    at YdDevice.sendPGN (.../dist/yddevice.js:37:18)
    at sendHeartbeat (.../dist/n2kDevice.js:351:12)
    at Timeout._onTimeout (.../dist/n2kDevice.js:387:17)
```

The `ydFullFormat` sender (`YdDevice.sendPGN`) already stamps `pgn.src` with its own claimed address before emitting, so leaving `pgn.src` intact when the receiving stream has no device is the correct behaviour.

## Repro

1. Configure a `ydwg02-udp-canboatjs` provider with `createDevice: true` and a host that is reachable for sending but silent on the return path (or just hasn't sent anything yet).
2. Wait ~6 s for the device's address claim to complete and `nmea2000OutAvailable` to fire.
3. Wait one heartbeat interval (60 s). The throw fires on every subsequent heartbeat and on every incoming ISO Request that the device tries to answer.

## Fix

`lib/ydgw02.ts` — extend the existing `pgn.src !== 254` guard to also require `this.device !== undefined` before overwriting `pgn.src`. Both branches of the surrounding conditional already handle the device-undefined case correctly otherwise.

## Tested

- All 188 existing tests pass (`npm test`).
- Live: rebuilt and `npm link`-ed into a Signal K server with the affected UDP YDWG02 provider configured. Server logs went from one throw per heartbeat (and one per inbound ISO Request) to clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where message transmission could fail if attempted before the device was fully initialized. The system now properly validates device readiness before attempting certain operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->