### PR TITLE
feat(canbus): respect options.createDevice (default true)

### DIFF
--- a/lib/canbus.ts
+++ b/lib/canbus.ts
@@ -260,8 +260,19 @@ CanbusStream.prototype.connect = function () {
 
     this.channel.start()
     this.setProviderStatus('Connected to CAN bus')
-    this.candevice = new CanDevice(this, this.options)
-    this.candevice.start()
+
+    // createDevice controls whether canboatjs claims its own N2K address
+    // on the bus. The historical default for this transport was "always
+    // on" — preserve that for back-compat by treating undefined as true.
+    // When explicitly disabled the stream stays receive-only: sendPGN
+    // becomes a no-op (the `if (this.candevice)` guard already covers
+    // that) and nmea2000OutAvailable is never emitted, which is the
+    // truth — without an address claim we have no source on the bus
+    // and cannot transmit.
+    if (this.options.createDevice !== false) {
+      this.candevice = new CanDevice(this, this.options)
+      this.candevice.start()
+    }
 
     // Recreate the no-data monitoring timer for this connection
     this._setupNoDataTimer()


### PR DESCRIPTION
## Summary

`CanbusStream` unconditionally instantiated a `CanDevice` and performed an N2K Address Claim. Useful for active setups but wrong for a SignalK server that should only listen on the bus — e.g. a secondary instance reading from a CAN gateway whose primary address is already claimed elsewhere, or an audit/recording use case where claiming an address would disrupt the real bus.

This PR introduces an opt-out via `options.createDevice`, matching the existing convention on `Ydgw02Stream` and `YdgwUdpStream`. When `createDevice === false`, the stream stays receive-only:

- `CanDevice` is not constructed.
- `sendPGN` becomes a no-op (the existing `if (this.candevice)` guard already covers that).
- `nmea2000OutAvailable` is intentionally not emitted, because without an address claim there is no source to transmit from. Callers (notably the SignalK server's N2K Discovery interface) see the truth and can warn the user that Discover / instance edits are unavailable on this connection.

**Default is `true`** so existing deployments behave identically.

## Repro / motivation

Reported via Signal K server beta testing. A user with a passive SignalK box on the same N2K bus as their primary navigation server wanted to disable address claiming to avoid conflicting with the active boat-level node. The UI exposes the toggle for YDGW gateways but not for socketcan because the underlying canboatjs stream had no equivalent option.

## Tested

- All 188 existing tests pass (`npm test`).
- TypeScript build clean.
- Manually traced every `this.candevice` reference in `lib/canbus.ts` to confirm each one is guarded (`if (this.candevice)`, `that.candevice && that.candevice.cansend`, etc.) so the receive path, dedup, send guard, and shutdown all handle the undefined case gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CANBUS stream initialization now conditionally creates the device based on configuration, allowing for receive-only operation when needed while maintaining backward compatibility with existing behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/427)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->