### PR TITLE
fix: ActisenseStream missing sendPGN; preserve prio when sending

### DIFF
--- a/lib/actisense-serial.test.ts
+++ b/lib/actisense-serial.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events'
+import { PGN } from '@canboat/ts-pgns'
 import { ActisenseStream, composeMessage } from './actisense-serial'
 
 const DLE = 0x10
@@ -212,5 +213,136 @@ describe('framing error recovery', () => {
 
     expect(rawOutputs).toHaveLength(0)
     expect(downstream).toHaveLength(0)
+  })
+})
+
+interface SendTestHarness {
+  instance: any
+  app: EventEmitter
+  writes: Buffer[]
+  rawSends: string[]
+}
+
+// Build a bare ActisenseStream wired to in-memory sinks so the send-path
+// prototype methods can be exercised without opening a serial port.
+function makeSendInstance(): SendTestHarness {
+  const app = new EventEmitter()
+  const writes: Buffer[] = []
+  const rawSends: string[] = []
+  app.on('canboatjs:rawsend', (e: { data: string }) => rawSends.push(e.data))
+
+  const instance: any = Object.create((ActisenseStream as any).prototype)
+  instance.options = { app, providerId: 'test' }
+  instance.outAvailable = true
+  instance.serial = { write: (buf: Buffer) => writes.push(buf) }
+  instance.debugOut = () => {}
+
+  return { instance, app, writes, rawSends }
+}
+
+const samplePGN = {
+  pgn: 127251,
+  prio: 6,
+  src: 17,
+  dst: 200,
+  fields: { rateOfTurn: 0 }
+} as unknown as PGN
+
+// Actisense CSV: <timestamp>,<prio>,<pgn>,<src>,<dst>,<len>,<bytes...>
+function actisenseFields(s: string) {
+  const parts = s.split(',')
+  return {
+    prio: Number(parts[1]),
+    pgn: Number(parts[2]),
+    src: Number(parts[3]),
+    dst: Number(parts[4])
+  }
+}
+
+describe('ActisenseStream.sendPGN', () => {
+  test('preserves prio and reports the NGT-1 send-frame source', () => {
+    const { instance, rawSends, writes } = makeSendInstance()
+    instance.sendPGN(samplePGN)
+
+    expect(writes).toHaveLength(1)
+    expect(rawSends).toHaveLength(1)
+    // src is reported as 0 because the NGT-1 transmits with its own
+    // claimed N2K address; pgn.src is not forwarded on the wire.
+    expect(actisenseFields(rawSends[0])).toEqual({
+      prio: 6,
+      pgn: 127251,
+      src: 0,
+      dst: 200
+    })
+  })
+
+  test('falls back to defaults when prio is not provided', () => {
+    const { instance, rawSends } = makeSendInstance()
+    instance.sendPGN({
+      pgn: 127251,
+      dst: 255,
+      fields: { rateOfTurn: 0 }
+    } as unknown as PGN)
+
+    expect(actisenseFields(rawSends[0])).toEqual({
+      prio: 2,
+      pgn: 127251,
+      src: 0,
+      dst: 255
+    })
+  })
+
+  test('does not write when outAvailable is false', () => {
+    const { instance, writes, rawSends } = makeSendInstance()
+    instance.outAvailable = false
+    instance.sendPGN(samplePGN)
+
+    expect(writes).toHaveLength(0)
+    expect(rawSends).toHaveLength(0)
+  })
+
+  test('emits connectionwrite when sending', () => {
+    const { instance, app } = makeSendInstance()
+    let connectionWrites = 0
+    app.on('connectionwrite', () => connectionWrites++)
+    instance.sendPGN(samplePGN)
+
+    expect(connectionWrites).toBe(1)
+  })
+})
+
+describe('ActisenseStream listener wiring', () => {
+  // The listener registration lives inside start(), which opens a serial
+  // port. Mirror just the listener-only portion so the event-to-method
+  // routing can be verified without touching hardware.
+  function wireListeners(instance: any) {
+    const app: EventEmitter = instance.options.app
+    app.on('nmea2000out', (msg: any) => {
+      if (typeof msg === 'string') {
+        instance.sendString(msg)
+      } else {
+        instance.sendPGN(msg)
+      }
+    })
+    app.on('nmea2000JsonOut', (msg: PGN) => instance.sendPGN(msg))
+  }
+
+  test('routes nmea2000JsonOut events through sendPGN', () => {
+    const { instance, app, rawSends } = makeSendInstance()
+    wireListeners(instance)
+    app.emit('nmea2000JsonOut', samplePGN)
+
+    expect(rawSends).toHaveLength(1)
+    expect(actisenseFields(rawSends[0]).prio).toBe(6)
+  })
+
+  test('routes nmea2000out string events through sendString', () => {
+    const { instance, app, rawSends } = makeSendInstance()
+    wireListeners(instance)
+    const raw =
+      '2026-05-07T20:35:05.606Z,6,61184,49,255,8,16,1c,4d,11,00,00,00,00'
+    app.emit('nmea2000out', raw)
+
+    expect(rawSends).toEqual([raw])
   })
 })

--- a/lib/actisense-serial.ts
+++ b/lib/actisense-serial.ts
@@ -154,47 +154,15 @@ ActisenseStream.prototype.start = function (this: any) {
     })
 
     if (this.options.app) {
-      const writeString = (msg: string) => {
-        this.debugOut(`sending ${msg}`)
-        let buf = parseInput(msg)
-        buf = composeMessage(N2K_MSG_SEND, buf, buf.length)
-        this.debugOut(buf)
-        this.serial.write(buf)
-        if (this.options.app.listenerCount('canboatjs:rawsend') > 0) {
-          this.options.app.emit('canboatjs:rawsend', { data: msg })
-        }
-        this.options.app.emit('connectionwrite', {
-          providerId: this.options.providerId
-        })
-      }
-
-      const writeObject = (msg: PGN) => {
-        const data = toPgn(msg)
-        const actisense = encodeActisense({ pgn: msg.pgn, data, dst: msg.dst })
-        this.debugOut(`sending ${actisense}`)
-        let buf = parseInput(actisense)
-        buf = composeMessage(N2K_MSG_SEND, buf, buf.length)
-        this.debugOut(buf)
-        this.serial.write(buf)
-        if (this.options.app.listenerCount('canboatjs:rawsend') > 0) {
-          this.options.app.emit('canboatjs:rawsend', { data: actisense })
-        }
-        this.options.app.emit('connectionwrite', {
-          providerId: this.options.providerId
-        })
-      }
-
       const outEvents = (this.options.outEvent || 'nmea2000out')
         .split(',')
         .map((event: string) => event.trim())
       outEvents.forEach((event: string) => {
-        this.options.app.on(event, (msg: string) => {
-          if (this.outAvailable) {
-            if (typeof msg === 'string') {
-              writeString(msg)
-            } else {
-              writeObject(msg)
-            }
+        this.options.app.on(event, (msg: any) => {
+          if (typeof msg === 'string') {
+            this.sendString(msg)
+          } else {
+            this.sendPGN(msg)
           }
         })
       })
@@ -204,9 +172,7 @@ ActisenseStream.prototype.start = function (this: any) {
         .map((event: string) => event.trim())
       jsonOutEvents.forEach((event: string) => {
         this.options.app.on(event, (msg: PGN) => {
-          if (this.outAvailable) {
-            writeObject(msg)
-          }
+          this.sendPGN(msg)
         })
       })
     }
@@ -254,6 +220,46 @@ ActisenseStream.prototype.start = function (this: any) {
       }
     })
   }
+}
+
+ActisenseStream.prototype.sendString = function (this: any, msg: string) {
+  if (!this.outAvailable) return
+  this.debugOut(`sending ${msg}`)
+  let buf = parseInput(msg)
+  buf = composeMessage(N2K_MSG_SEND, buf, buf.length)
+  this.debugOut(buf)
+  this.serial.write(buf)
+  if (this.options.app.listenerCount('canboatjs:rawsend') > 0) {
+    this.options.app.emit('canboatjs:rawsend', { data: msg })
+  }
+  this.options.app.emit('connectionwrite', {
+    providerId: this.options.providerId
+  })
+}
+
+ActisenseStream.prototype.sendPGN = function (this: any, pgn: PGN) {
+  if (!this.outAvailable) return
+  const data = toPgn(pgn)
+  const actisense = encodeActisense({
+    pgn: pgn.pgn,
+    data,
+    dst: pgn.dst,
+    // NGT-1 send frames do not carry a caller-provided source address;
+    // the gateway transmits using its own claimed NMEA 2000 address.
+    src: 0,
+    prio: pgn.prio
+  })
+  this.debugOut(`sending ${actisense}`)
+  let buf = parseInput(actisense)
+  buf = composeMessage(N2K_MSG_SEND, buf, buf.length)
+  this.debugOut(buf)
+  this.serial.write(buf)
+  if (this.options.app.listenerCount('canboatjs:rawsend') > 0) {
+    this.options.app.emit('canboatjs:rawsend', { data: actisense })
+  }
+  this.options.app.emit('connectionwrite', {
+    providerId: this.options.providerId
+  })
 }
 
 ActisenseStream.prototype.scheduleReconnect = function () {


### PR DESCRIPTION
## Summary

  `ActisenseStream` was the only transport without a `sendPGN` prototype method — the write logic lived in a closure inside `start()`, reachable only via the `nmea2000out` / `nmea2000JsonOut` event bus. Consumers that hold the stream instance and call `sendPGN()` directly (the way they would on every other transport) crashed with:

  ```
  TypeError: this.stream.sendPGN is not a function
  ```

  The same closure also dropped `prio` when calling `encodeActisense`, so PGNs sent via `nmea2000JsonOut` always went out at the default prio 2.

  Hoist `writeObject` → `ActisenseStream.prototype.sendPGN` and `writeString` → `ActisenseStream.prototype.sendString` to match every other transport, and thread `prio` through to
  `encodeActisense`. The `outAvailable` gate moves into the prototype methods; listener wiring in `start()` becomes a thin delegate.

  ## Tests

  Six new jest cases in `lib/actisense-serial.test.ts` covering `prio` preservation, defaults, the `outAvailable` no-op, `connectionwrite` emission, and listener routing. `npm
  test` → 188 mocha passing + 12 jest passing.

  Surfaced from canboat/visual-analyzer#129.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for message transmission, verifying priority handling, event routing, and default fallback behavior.

* **Refactor**
  * Improved internal message transmission logic with clearer method separation for better code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/428)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->