### PR TITLE
fix(fromPgn): skip '#'-prefixed banner lines emitted by canboat tools

### DIFF
--- a/lib/fromPgn.ts
+++ b/lib/fromPgn.ts
@@ -941,6 +941,10 @@ export class Parser extends EventEmitter {
   }
 
   parseString(pgn_data: string, cb: FromPgnCallback | undefined = undefined) {
+    // skip format-banner lines emitted by canboat tools since canboat#573
+    if (pgn_data.startsWith('#')) {
+      return
+    }
     try {
       const { coalesced, data, error, len, ...pgn } = parseN2kString(
         pgn_data,


### PR DESCRIPTION
canboat tools since canboat/canboat#573 (actisense-serial, ikonvert-serial) emit `# format=FAST` as their first stdout line to trigger FAST format in analyzer. `parseN2kString` has no comment-line handling and falls through to `MISSING_PARSER` which throws an error that is logged.

Short-circuit `parseString` on '#'-prefixed input so banner / comment lines are silently dropped before the format-detection cascade runs.

Happy to redo this as `isComment(str)` in `parseN2kString` if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The parser now correctly ignores comment lines starting with `#`, preventing them from being misinterpreted as data payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->