### PR TITLE
fix(fromPgn): never emit NaN from convertField

### DIFF
--- a/lib/fromPgn.ts
+++ b/lib/fromPgn.ts
@@ -1224,6 +1224,12 @@ function convertField(
       }
     }
   }
+  // Numeric fields must never emit NaN: downstream consumers (e.g. databases
+  // doing BigInt(value * 1e9) for nanosecond conversion) will throw on NaN
+  // but handle null. Treat NaN the same as an out-of-range / invalid value.
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return null
+  }
   return value
 }
 


### PR DESCRIPTION
## Summary

`convertField` could return `NaN` for numeric fields when an intermediate computation went wrong (e.g. a `Resolution` string that parses to `NaN`, or any unexpected non-finite intermediate). The rest of the parser propagates the value as-is and downstream consumers see a numeric field with value `NaN`.

Consumers that convert delta values to nanoseconds via `BigInt(value * 1e9)` — for example `signalk-questdb`'s ILPWriter — throw a `RangeError: The number NaN cannot be converted to a BigInt because it is not an integer`. With a steady stream of N2K data (CAN0, ASCII formats, etc.) this spams the server log and drops legitimate writes.

## Fix

Reject any non-finite number at the `convertField` boundary, treating it the same as an out-of-range / invalid field (return `null`). `null` is what downstream code already expects for invalid fields, so the rest of the pipeline handles it cleanly.

## Test plan

- [x] `npm test` (44 jest + 188 mocha, all pass)
- [x] `npm run ci-lint` (no changes to other files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric fields now consistently return null for invalid values instead of returning non-finite numbers like NaN or Infinity, improving data reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->