### PR TITLE
feat(w2k01): act as a CAN device when actAsDevice is enabled

### DIFF
--- a/lib/w2k01.ts
+++ b/lib/w2k01.ts
@@ -24,6 +24,7 @@ import {
   actisenseToN2KActisenseFormat
 } from './toPgn'
 import { readN2KActisense } from './n2k-actisense'
+import { CanDevice } from './candevice'
 import util from 'util'
 
 //const pgnsSent = {}
@@ -85,6 +86,16 @@ export function W2K01Stream(
         })
       })
     }
+
+    // When asked to "act as a CAN device", instantiate a CanDevice so we
+    // respond to ISO Address Claim, Product Information, Heartbeat, etc.
+    // The CanDevice listens for inbound parsed PGNs on `N2KAnalyzerOut`
+    // (emitted by the CanboatJs pipe element) and calls back into our
+    // `sendPGN` to deliver its responses through the W2K-1 ASCII encoder.
+    if (options.app && options.actAsDevice) {
+      this.candevice = new CanDevice(this, options)
+      this.candevice.start()
+    }
   }
 
   this.debug('started')
@@ -95,7 +106,10 @@ W2K01Stream.prototype.send = function (msg: string | Buffer) {
   this.options.app.emit(this.outEvent, msg)
 }
 
-W2K01Stream.prototype.sendPGN = function (pgn: PGN) {
+// The optional `_force` parameter is part of the contract `CanDevice` uses to
+// drive its host transport; we always accept the PGN since the W2K-1 has no
+// "address claim pending" gating of its own.
+W2K01Stream.prototype.sendPGN = function (pgn: PGN, _force?: boolean) {
   //const now = Date.now()
   //let lastSent = pgnsSent[pgn.pgn]
   if (this.format === N2K_ASCII) {
@@ -167,4 +181,9 @@ W2K01Stream.prototype.pipe = function (pipeTo: any) {
   return (W2K01Stream as any).super_.prototype.pipe.call(this, pipeTo)
 }
 
-W2K01Stream.prototype.end = function () {}
+W2K01Stream.prototype.end = function () {
+  if (this.candevice) {
+    this.candevice.stop()
+    this.candevice = undefined
+  }
+}


### PR DESCRIPTION
## Summary

The W2K-1 (and similar Wavestream-style) ASCII bridge already supports encoding outgoing PGNs to the N2K bus, but `W2K01Stream` had no device identity of its own — it never participated in ISO Address Claim or responded to Product Information / Heartbeat requests. From the bus perspective, signalk-server data was being emitted by an unclaimed source, which some MFDs and routers may filter or refuse.

This mirrors the pattern that `simpleCan`, `canbus`, and `ydgw02` already use: when the caller opts in with `actAsDevice: true`, instantiate a `CanDevice` against the stream. The CanDevice picks up parsed PGNs via the existing `N2KAnalyzerOut` event and routes its responses back through our `sendPGN`, which encodes them via `pgnToActisenseN2KAsciiFormat`.

## Usage

In a signalk-server `subOptions` for a `w2k-1-n2k-ascii-canboatjs` connection:

```json
{
  "type": "w2k-1-n2k-ascii-canboatjs",
  "host": "192.168.0.120",
  "port": "2599",
  "useCanName": true,
  "actAsDevice": true
}
```

Standard `addressClaim` / `productInfo` / `uniqueNumber` options are honored if supplied; otherwise `N2kDevice` defaults apply.

## Why opt-in

Other transports (canbus, simpleCan, ydgw02) instantiate a CanDevice unconditionally because they are full-duplex by design. W2K-1 connections can be used read-only, so adding a device claim by default would be a behavior change for existing users.

## Test plan

- [x] `npm test` (44 jest + 188 mocha, all pass)
- [x] `npm run ci-lint`
- [x] Verified diff is contained to `lib/w2k01.ts` and adds no new dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * W2K01Stream can now optionally operate as a CAN device when configured with appropriate options.

* **Improvements**
  * Enhanced shutdown and cleanup procedures for better resource management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->