### PR TITLE
fix(fromPgn): fall back to current time for non-ISO timestamps

### DIFF
--- a/lib/fromPgn.ts
+++ b/lib/fromPgn.ts
@@ -726,7 +726,16 @@ export class Parser extends EventEmitter {
 
       // Stringify timestamp because SK Server needs it that way.
       const ts = _.get(pgn, 'timestamp', new Date())
-      res.timestamp = _.isDate(ts) ? ts.toISOString() : ts
+      if (_.isDate(ts) && Number.isFinite(ts.getTime())) {
+        res.timestamp = ts.toISOString()
+      } else if (typeof ts === 'string' && !isNaN(new Date(ts).getTime())) {
+        res.timestamp = ts
+      } else {
+        // Non-ISO timestamps from formats like candump (e.g. "(1502979132.106111)")
+        // would otherwise propagate downstream and produce "Invalid Date" in
+        // consumers. Fall back to current time.
+        res.timestamp = new Date().toISOString()
+      }
       this.emit('pgn', res)
       cb && cb(undefined, res)
 


### PR DESCRIPTION
## Summary
`parseCandump3` (and any other parser that writes a non-ISO `timestamp` into the pgn) leaks raw uptime strings like `"(1502979132.106111)"` through `_parse` into the emitted `res.timestamp`. Downstream consumers that assume an ISO date string then misrender it — e.g. `@signalk/n2k-signalk` slices the string at fixed positions and signalk-server's Data Browser feeds the result to `dayjs(...)`, producing `Invalid Date` on every row from a W2K-1 ASCII source.

This was reproducible in production: deltas arrived with `timestamp: "(57.205995T"` because the non-ISO `"(57.205995)"` survived `_parse` unchanged.

## Fix
In `_parse`, treat any non-`Date` timestamp that does not parse as a valid `Date` as missing and substitute `new Date().toISOString()`.

- `Date` instance → `.toISOString()` (unchanged)
- ISO-parseable string → passed through (unchanged)
- Anything else → current time (new behavior, was: passed through verbatim)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling: Date values are now consistently converted to ISO strings, valid timestamp-like strings are preserved, and invalid or unrecognized timestamps are replaced with the current time’s ISO string to prevent malformed or missing timestamp data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->