### PR TITLE
fix(stringMsg): return error for malformed candump3 lines instead of throwing

### DIFF
--- a/lib/stringMsg.ts
+++ b/lib/stringMsg.ts
@@ -426,10 +426,23 @@ export const encodeCandump2 = ({
 
 // candump3 log
 // (1502979132.106111) slcan0 09F50374#000A00FFFF00FFFF
-export const isCandump3 = startsWith('(')
+export const isCandump3 = (input: string) =>
+  input.charAt(0) === '(' && input.indexOf('#') > 0
 export const parseCandump3 = (input: string) => {
-  const [timestamp, bus, canFrame] = input.split(' ')
-  const [canId, data] = canFrame.split('#')
+  const parts = input.split(' ')
+  if (parts.length !== 3) {
+    return buildErr('candump3', 'Malformed candump3 line', input)
+  }
+  const [timestamp, bus, canFrame] = parts
+  const hashIdx = canFrame.indexOf('#')
+  if (hashIdx <= 0 || hashIdx === canFrame.length - 1) {
+    return buildErr('candump3', 'Malformed candump3 frame', input)
+  }
+  const canId = canFrame.substring(0, hashIdx)
+  const data = canFrame.substring(hashIdx + 1)
+  if (!/^[0-9A-Fa-f]+$/.test(data)) {
+    return buildErr('candump3', 'Non-hex candump3 data', input)
+  }
   return buildMsg(parseCanIdStr(canId), 'candump3', Buffer.from(data, 'hex'), {
     timestamp,
     bus


### PR DESCRIPTION
## Summary
Observed on a real Wavestream W2K-1 stream: the device occasionally emits two messages concatenated onto a single line, e.g.

```
(160.132419) can0 0DF11904#FFA97(160.132974) can0 09F11204#FFA974FF7F8308FC
(164.545995) can0 09(164.546563) can0 1DFF1D04#933011FFFFFF7F19
```

`parseCandump3` did `input.split(' ')` and then `canFrame.split('#')` and passed the right half to `Buffer.from(data, 'hex')`. For the truncated/glued lines above, `canFrame.split('#')` yields a single element, `data` is `undefined`, and `Buffer.from(undefined, 'hex')` throws `TypeError: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined` — the exception escapes the parser, is caught by the host pipeline (e.g. signalk-server prints it to stderr), and the host now logs the error for *every* malformed line.

## Fix
- Tighten `isCandump3` to also require a `#` in the line, so non-candump lines starting with `(` are no longer routed to this parser.
- Validate line shape in `parseCandump3` and return a `buildErr()` result for malformed input, the way the other parsers in this file already do, instead of throwing.

No behavior change for well-formed candump3 lines (verified with the test suite, all 188 passing, plus the recorded malformed lines now produce a clean error result instead of crashing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CAN data format parsing now validates input structure more thoroughly and provides clearer error messages for malformed entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->