### PR TITLE
feat: configurable device-instance fields + uniqueNumber emit fix in N2kDevice

### DIFF
--- a/lib/n2kDevice.test.ts
+++ b/lib/n2kDevice.test.ts
@@ -1,0 +1,104 @@
+// Unit tests for N2kDevice address claim option mapping.
+
+jest.mock('./persist', () => ({
+  getPersistedData: jest.fn(() => undefined),
+  savePersistedData: jest.fn()
+}))
+
+import { CanDevice } from './candevice'
+
+function makeOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    // app is required for CanDevice to register its analyzer listener.
+    // Use a minimal stub so the constructor doesn't blow up.
+    app: { on: () => undefined, removeListener: () => undefined },
+    providerId: 'test',
+    uniqueNumber: 12345,
+    ...overrides
+  }
+}
+
+describe('N2kDevice address claim options', () => {
+  test('defaults: deviceInstanceLower=0, deviceInstanceUpper=0, systemInstance=0', () => {
+    const dev = new CanDevice({ sendPGN: () => undefined }, makeOptions())
+    const ac: any = dev.addressClaim
+    expect(ac.fields.deviceInstanceLower).toBe(0)
+    expect(ac.fields.deviceInstanceUpper).toBe(0)
+    expect(ac.fields.systemInstance).toBe(0)
+    dev.stop()
+  })
+
+  test('combined deviceInstance = 5 → lower=5, upper=0', () => {
+    const dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({ deviceInstance: 5 })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.deviceInstanceLower).toBe(5)
+    expect(ac.fields.deviceInstanceUpper).toBe(0)
+    dev.stop()
+  })
+
+  test('combined deviceInstance = 12 → lower=4, upper=1', () => {
+    // 12 = (1<<3) | 4
+    const dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({ deviceInstance: 12 })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.deviceInstanceLower).toBe(4)
+    expect(ac.fields.deviceInstanceUpper).toBe(1)
+    dev.stop()
+  })
+
+  test('combined deviceInstance = 255 → lower=7, upper=31', () => {
+    const dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({ deviceInstance: 255 })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.deviceInstanceLower).toBe(7)
+    expect(ac.fields.deviceInstanceUpper).toBe(31)
+    dev.stop()
+  })
+
+  test('explicit deviceInstanceLower / deviceInstanceUpper override combined', () => {
+    const dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({
+        deviceInstance: 0, // would split to (0,0)
+        deviceInstanceLower: 3,
+        deviceInstanceUpper: 9
+      })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.deviceInstanceLower).toBe(3)
+    expect(ac.fields.deviceInstanceUpper).toBe(9)
+    dev.stop()
+  })
+
+  test('systemInstance = 7 is applied', () => {
+    const dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({ systemInstance: 7 })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.systemInstance).toBe(7)
+    dev.stop()
+  })
+
+  test('non-numeric instance values fall back to 0', () => {
+    const dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({
+        deviceInstance: 'huh',
+        systemInstance: null
+      })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.deviceInstanceLower).toBe(0)
+    expect(ac.fields.deviceInstanceUpper).toBe(0)
+    expect(ac.fields.systemInstance).toBe(0)
+    dev.stop()
+  })
+})

--- a/lib/n2kDevice.test.ts
+++ b/lib/n2kDevice.test.ts
@@ -19,6 +19,16 @@ function makeOptions(overrides: Record<string, unknown> = {}) {
 }
 
 describe('N2kDevice address claim options', () => {
+  test('uniqueNumber from options lands on addressClaim.fields (not top-level)', () => {
+    const dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({ uniqueNumber: 1150522 })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.uniqueNumber).toBe(1150522)
+    dev.stop()
+  })
+
   test('defaults: deviceInstanceLower=0, deviceInstanceUpper=0, systemInstance=0', () => {
     const dev = new CanDevice({ sendPGN: () => undefined }, makeOptions())
     const ac: any = dev.addressClaim

--- a/lib/n2kDevice.test.ts
+++ b/lib/n2kDevice.test.ts
@@ -87,6 +87,18 @@ describe('N2kDevice address claim options', () => {
     dev.stop()
   })
 
+  test('numeric strings ("3") are coerced — admin UI form inputs deliver strings', () => {
+    const dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({ deviceInstance: '3', systemInstance: '5' })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.deviceInstanceLower).toBe(3)
+    expect(ac.fields.deviceInstanceUpper).toBe(0)
+    expect(ac.fields.systemInstance).toBe(5)
+    dev.stop()
+  })
+
   test('non-numeric instance values fall back to 0', () => {
     const dev = new CanDevice(
       { sendPGN: () => undefined },

--- a/lib/n2kDevice.test.ts
+++ b/lib/n2kDevice.test.ts
@@ -31,6 +31,37 @@ describe('N2kDevice address claim options', () => {
     }
   })
 
+  test('caller-supplied addressClaim with legacy top-level uniqueNumber is honored', () => {
+    // Older callers passed an addressClaim object with `uniqueNumber`
+    // (or the human-readable `'Unique Number'`) at the top level.
+    // The encoder ignores both and reads `.fields.uniqueNumber` only,
+    // so we promote the legacy value into `.fields` rather than letting
+    // options.uniqueNumber / persistence silently overwrite it.
+    const legacyClaim: any = { uniqueNumber: 7777777 }
+    dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({
+        addressClaim: legacyClaim,
+        uniqueNumber: 1111111 // would otherwise win
+      })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.uniqueNumber).toBe(7777777)
+  })
+
+  test('caller-supplied addressClaim with .fields.uniqueNumber is honored', () => {
+    const claim: any = { fields: { uniqueNumber: 8888888 } }
+    dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({
+        addressClaim: claim,
+        uniqueNumber: 2222222 // would otherwise win
+      })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.uniqueNumber).toBe(8888888)
+  })
+
   test('uniqueNumber from options lands on addressClaim.fields (not top-level)', () => {
     dev = new CanDevice(
       { sendPGN: () => undefined },

--- a/lib/n2kDevice.test.ts
+++ b/lib/n2kDevice.test.ts
@@ -19,61 +19,68 @@ function makeOptions(overrides: Record<string, unknown> = {}) {
 }
 
 describe('N2kDevice address claim options', () => {
+  // Hoisted so afterEach can stop the device created in each test even
+  // if the test body throws — otherwise a failing assertion leaks the
+  // addressClaimChecker / heartbeatInterval into the next test run.
+  let dev: CanDevice | undefined
+
+  afterEach(() => {
+    if (dev) {
+      dev.stop()
+      dev = undefined
+    }
+  })
+
   test('uniqueNumber from options lands on addressClaim.fields (not top-level)', () => {
-    const dev = new CanDevice(
+    dev = new CanDevice(
       { sendPGN: () => undefined },
       makeOptions({ uniqueNumber: 1150522 })
     )
     const ac: any = dev.addressClaim
     expect(ac.fields.uniqueNumber).toBe(1150522)
-    dev.stop()
   })
 
   test('defaults: deviceInstanceLower=0, deviceInstanceUpper=0, systemInstance=0', () => {
-    const dev = new CanDevice({ sendPGN: () => undefined }, makeOptions())
+    dev = new CanDevice({ sendPGN: () => undefined }, makeOptions())
     const ac: any = dev.addressClaim
     expect(ac.fields.deviceInstanceLower).toBe(0)
     expect(ac.fields.deviceInstanceUpper).toBe(0)
     expect(ac.fields.systemInstance).toBe(0)
-    dev.stop()
   })
 
   test('combined deviceInstance = 5 → lower=5, upper=0', () => {
-    const dev = new CanDevice(
+    dev = new CanDevice(
       { sendPGN: () => undefined },
       makeOptions({ deviceInstance: 5 })
     )
     const ac: any = dev.addressClaim
     expect(ac.fields.deviceInstanceLower).toBe(5)
     expect(ac.fields.deviceInstanceUpper).toBe(0)
-    dev.stop()
   })
 
   test('combined deviceInstance = 12 → lower=4, upper=1', () => {
     // 12 = (1<<3) | 4
-    const dev = new CanDevice(
+    dev = new CanDevice(
       { sendPGN: () => undefined },
       makeOptions({ deviceInstance: 12 })
     )
     const ac: any = dev.addressClaim
     expect(ac.fields.deviceInstanceLower).toBe(4)
     expect(ac.fields.deviceInstanceUpper).toBe(1)
-    dev.stop()
   })
 
   test('combined deviceInstance = 255 → lower=7, upper=31', () => {
-    const dev = new CanDevice(
+    dev = new CanDevice(
       { sendPGN: () => undefined },
       makeOptions({ deviceInstance: 255 })
     )
     const ac: any = dev.addressClaim
     expect(ac.fields.deviceInstanceLower).toBe(7)
     expect(ac.fields.deviceInstanceUpper).toBe(31)
-    dev.stop()
   })
 
   test('explicit deviceInstanceLower / deviceInstanceUpper override combined', () => {
-    const dev = new CanDevice(
+    dev = new CanDevice(
       { sendPGN: () => undefined },
       makeOptions({
         deviceInstance: 0, // would split to (0,0)
@@ -84,21 +91,19 @@ describe('N2kDevice address claim options', () => {
     const ac: any = dev.addressClaim
     expect(ac.fields.deviceInstanceLower).toBe(3)
     expect(ac.fields.deviceInstanceUpper).toBe(9)
-    dev.stop()
   })
 
   test('systemInstance = 7 is applied', () => {
-    const dev = new CanDevice(
+    dev = new CanDevice(
       { sendPGN: () => undefined },
       makeOptions({ systemInstance: 7 })
     )
     const ac: any = dev.addressClaim
     expect(ac.fields.systemInstance).toBe(7)
-    dev.stop()
   })
 
   test('numeric strings ("3") are coerced — admin UI form inputs deliver strings', () => {
-    const dev = new CanDevice(
+    dev = new CanDevice(
       { sendPGN: () => undefined },
       makeOptions({ deviceInstance: '3', systemInstance: '5' })
     )
@@ -106,11 +111,10 @@ describe('N2kDevice address claim options', () => {
     expect(ac.fields.deviceInstanceLower).toBe(3)
     expect(ac.fields.deviceInstanceUpper).toBe(0)
     expect(ac.fields.systemInstance).toBe(5)
-    dev.stop()
   })
 
   test('non-numeric instance values fall back to 0', () => {
-    const dev = new CanDevice(
+    dev = new CanDevice(
       { sendPGN: () => undefined },
       makeOptions({
         deviceInstance: 'huh',
@@ -121,6 +125,38 @@ describe('N2kDevice address claim options', () => {
     expect(ac.fields.deviceInstanceLower).toBe(0)
     expect(ac.fields.deviceInstanceUpper).toBe(0)
     expect(ac.fields.systemInstance).toBe(0)
-    dev.stop()
+  })
+
+  test('out-of-range values fall back to 0 (no silent bit-mask wrap)', () => {
+    // Bit-masking a 257 produces deviceInstance=1, which surprises the
+    // user who set it to 257 thinking the bus would carry that exact
+    // value. Drop the input on the floor instead.
+    dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({
+        deviceInstance: 257,
+        deviceInstanceLower: 8, // > 0x07
+        deviceInstanceUpper: 32, // > 0x1f
+        systemInstance: 16 // > 0x0f
+      })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.deviceInstanceLower).toBe(0)
+    expect(ac.fields.deviceInstanceUpper).toBe(0)
+    expect(ac.fields.systemInstance).toBe(0)
+  })
+
+  test('negative values fall back to 0', () => {
+    dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({
+        deviceInstance: -1,
+        systemInstance: -5
+      })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.deviceInstanceLower).toBe(0)
+    expect(ac.fields.deviceInstanceUpper).toBe(0)
+    expect(ac.fields.systemInstance).toBe(0)
   })
 })

--- a/lib/n2kDevice.test.ts
+++ b/lib/n2kDevice.test.ts
@@ -49,6 +49,22 @@ describe('N2kDevice address claim options', () => {
     expect(ac.fields.uniqueNumber).toBe(7777777)
   })
 
+  test("caller-supplied addressClaim with legacy 'Unique Number' key is honored", () => {
+    // Same fallback as the previous test, but supplied via the
+    // human-readable key the canboat JSON uses. Exercises the
+    // `ac['Unique Number']` arm of the `??` chain.
+    const legacyClaim: any = { 'Unique Number': 9999999 }
+    dev = new CanDevice(
+      { sendPGN: () => undefined },
+      makeOptions({
+        addressClaim: legacyClaim,
+        uniqueNumber: 1111111 // would otherwise win
+      })
+    )
+    const ac: any = dev.addressClaim
+    expect(ac.fields.uniqueNumber).toBe(9999999)
+  })
+
   test('caller-supplied addressClaim with .fields.uniqueNumber is honored', () => {
     const claim: any = { fields: { uniqueNumber: 8888888 } }
     dev = new CanDevice(

--- a/lib/n2kDevice.ts
+++ b/lib/n2kDevice.ts
@@ -85,6 +85,28 @@ export class N2kDevice extends EventEmitter {
       this.addressClaim.dst = 255
       this.addressClaim.prio = 6
     } else {
+      // Device Instance: 8-bit identifier built from a 3-bit "lower"
+      // and a 5-bit "upper" field, mirroring the N2K standard. We
+      // accept a single combined value 0-255 via options.deviceInstance
+      // and split it; individual lower/upper overrides also work for
+      // users that want to set them explicitly.
+      const combinedInstance =
+        typeof options.deviceInstance === 'number'
+          ? options.deviceInstance & 0xff
+          : 0
+      const deviceInstanceLower =
+        typeof options.deviceInstanceLower === 'number'
+          ? options.deviceInstanceLower & 0x07
+          : combinedInstance & 0x07
+      const deviceInstanceUpper =
+        typeof options.deviceInstanceUpper === 'number'
+          ? options.deviceInstanceUpper & 0x1f
+          : (combinedInstance >> 3) & 0x1f
+      const systemInstance =
+        typeof options.systemInstance === 'number'
+          ? options.systemInstance & 0x0f
+          : 0
+
       this.addressClaim = new PGN_60928(
         {
           manufacturerCode:
@@ -93,9 +115,9 @@ export class N2kDevice extends EventEmitter {
               : 999,
           deviceFunction: 130, // PC gateway
           deviceClass: 25, // Inter/Intranetwork Device
-          deviceInstanceLower: 0,
-          deviceInstanceUpper: 0,
-          systemInstance: 0,
+          deviceInstanceLower,
+          deviceInstanceUpper,
+          systemInstance,
           industryGroup: 4, // Marine
           arbitraryAddressCapable: YesNo.Yes
         },

--- a/lib/n2kDevice.ts
+++ b/lib/n2kDevice.ts
@@ -129,8 +129,16 @@ export class N2kDevice extends EventEmitter {
       )
     }
 
-    if (this.addressClaim['Unique Number'] === undefined) {
-      this.addressClaim.uniqueNumber = uniqueNumber
+    // PGN_60928 stores its NMEA fields in `.fields` (canboat camelCase Id
+    // form). Older canboatjs code set a top-level `uniqueNumber` /
+    // `'Unique Number'` property, which the encoder ignored — meaning every
+    // signalk-server claim went out with the all-ones (0x1FFFFF) sentinel
+    // unique number. Some N2K analyzers (e.g. Maretron) treat that value
+    // as factory-default and hide the device. Set it on `.fields` directly.
+    const ac: any = this.addressClaim
+    const fields = (ac.fields = ac.fields || {})
+    if (fields.uniqueNumber === undefined) {
+      fields.uniqueNumber = uniqueNumber
     }
 
     const version = packageJson ? packageJson.version : '1.0'

--- a/lib/n2kDevice.ts
+++ b/lib/n2kDevice.ts
@@ -90,26 +90,37 @@ export class N2kDevice extends EventEmitter {
       // accept a single combined value 0-255 via options.deviceInstance
       // and split it; individual lower/upper overrides also work for
       // users that want to set them explicitly.
-      // Coerce numeric strings ("3") to numbers — admin UI form inputs
-      // and settings.json may carry the value as a string.
-      const toInt = (v: unknown): number | undefined => {
-        if (typeof v === 'number' && Number.isFinite(v)) return Math.trunc(v)
-        if (typeof v === 'string' && v.trim() !== '') {
-          const n = Number(v)
-          if (Number.isFinite(n)) return Math.trunc(n)
+      //
+      // Inputs that fall outside the documented range (or aren't a
+      // finite integer-coercible value at all) are dropped silently
+      // back to 0. We deliberately do NOT bit-mask out-of-range
+      // numbers: silently emitting `255 → 0` from a user-set
+      // deviceInstance of e.g. 257 would be more surprising than the
+      // fallback. Numeric-string forms ("3") are accepted because
+      // the admin UI's <input type="number"> ships values as strings.
+      const toIntInRange = (
+        v: unknown,
+        min: number,
+        max: number
+      ): number | undefined => {
+        let n: number | undefined
+        if (typeof v === 'number' && Number.isFinite(v)) n = Math.trunc(v)
+        else if (typeof v === 'string' && v.trim() !== '') {
+          const parsed = Number(v)
+          if (Number.isFinite(parsed)) n = Math.trunc(parsed)
         }
-        return undefined
+        if (n === undefined || n < min || n > max) return undefined
+        return n
       }
-      const combined = toInt(options.deviceInstance) ?? 0
-      const explicitLower = toInt(options.deviceInstanceLower)
-      const explicitUpper = toInt(options.deviceInstanceUpper)
-      const explicitSystem = toInt(options.systemInstance)
+      const combined = toIntInRange(options.deviceInstance, 0, 0xff) ?? 0
+      const explicitLower = toIntInRange(options.deviceInstanceLower, 0, 0x07)
+      const explicitUpper = toIntInRange(options.deviceInstanceUpper, 0, 0x1f)
+      const explicitSystem = toIntInRange(options.systemInstance, 0, 0x0f)
       const deviceInstanceLower =
-        (explicitLower !== undefined ? explicitLower : combined) & 0x07
+        explicitLower !== undefined ? explicitLower : combined & 0x07
       const deviceInstanceUpper =
-        (explicitUpper !== undefined ? explicitUpper : combined >> 3) & 0x1f
-      const systemInstance =
-        (explicitSystem !== undefined ? explicitSystem : 0) & 0x0f
+        explicitUpper !== undefined ? explicitUpper : (combined >> 3) & 0x1f
+      const systemInstance = explicitSystem !== undefined ? explicitSystem : 0
 
       this.addressClaim = new PGN_60928(
         {

--- a/lib/n2kDevice.ts
+++ b/lib/n2kDevice.ts
@@ -90,22 +90,26 @@ export class N2kDevice extends EventEmitter {
       // accept a single combined value 0-255 via options.deviceInstance
       // and split it; individual lower/upper overrides also work for
       // users that want to set them explicitly.
-      const combinedInstance =
-        typeof options.deviceInstance === 'number'
-          ? options.deviceInstance & 0xff
-          : 0
+      // Coerce numeric strings ("3") to numbers — admin UI form inputs
+      // and settings.json may carry the value as a string.
+      const toInt = (v: unknown): number | undefined => {
+        if (typeof v === 'number' && Number.isFinite(v)) return Math.trunc(v)
+        if (typeof v === 'string' && v.trim() !== '') {
+          const n = Number(v)
+          if (Number.isFinite(n)) return Math.trunc(n)
+        }
+        return undefined
+      }
+      const combined = toInt(options.deviceInstance) ?? 0
+      const explicitLower = toInt(options.deviceInstanceLower)
+      const explicitUpper = toInt(options.deviceInstanceUpper)
+      const explicitSystem = toInt(options.systemInstance)
       const deviceInstanceLower =
-        typeof options.deviceInstanceLower === 'number'
-          ? options.deviceInstanceLower & 0x07
-          : combinedInstance & 0x07
+        (explicitLower !== undefined ? explicitLower : combined) & 0x07
       const deviceInstanceUpper =
-        typeof options.deviceInstanceUpper === 'number'
-          ? options.deviceInstanceUpper & 0x1f
-          : (combinedInstance >> 3) & 0x1f
+        (explicitUpper !== undefined ? explicitUpper : combined >> 3) & 0x1f
       const systemInstance =
-        typeof options.systemInstance === 'number'
-          ? options.systemInstance & 0x0f
-          : 0
+        (explicitSystem !== undefined ? explicitSystem : 0) & 0x0f
 
       this.addressClaim = new PGN_60928(
         {

--- a/lib/n2kDevice.ts
+++ b/lib/n2kDevice.ts
@@ -145,11 +145,22 @@ export class N2kDevice extends EventEmitter {
     // `'Unique Number'` property, which the encoder ignored — meaning every
     // signalk-server claim went out with the all-ones (0x1FFFFF) sentinel
     // unique number. Some N2K analyzers (e.g. Maretron) treat that value
-    // as factory-default and hide the device. Set it on `.fields` directly.
+    // as factory-default and hide the device.
+    //
+    // Honor any uniqueNumber the caller already set on the supplied
+    // addressClaim — both the canonical `.fields.uniqueNumber` form and
+    // the legacy top-level `uniqueNumber` / `'Unique Number'` shapes —
+    // before backfilling from options/persistence. This preserves a
+    // caller-supplied claim's identity instead of silently overwriting it.
     const ac: any = this.addressClaim
     const fields = (ac.fields = ac.fields || {})
     if (fields.uniqueNumber === undefined) {
-      fields.uniqueNumber = uniqueNumber
+      const legacy = ac.uniqueNumber ?? ac['Unique Number']
+      if (legacy !== undefined) {
+        fields.uniqueNumber = legacy
+      } else {
+        fields.uniqueNumber = uniqueNumber
+      }
     }
 
     const version = packageJson ? packageJson.version : '1.0'


### PR DESCRIPTION
## Summary

Three improvements to `N2kDevice` / `CanDevice`'s PGN 60928 address claim that benefit every canboatjs source (canbus, ydgw02, w2k01, ikonvert, the new N2kIpGateway in #437). Split out from #437 at maintainer request.

## Commits

1. **`expose deviceInstance + systemInstance in CanDevice options`** — `N2kDevice` previously hardcoded `deviceInstanceLower / deviceInstanceUpper / systemInstance` to 0 in its address claim, so multiple signalk-server nodes (or any two canboatjs-driven nodes) on the same N2K bus were indistinguishable. Threads three new pass-through options through the constructor: combined `deviceInstance` 0–255 (canboatjs splits it into the 3-bit lower + 5-bit upper fields per the N2K standard), plus optional explicit `deviceInstanceLower / deviceInstanceUpper` overrides, plus `systemInstance` 0–15. Defaults remain 0 — no-op for existing setups.
2. **`coerce numeric-string instance values from admin UI`** — admin UI `<input type="number">` ships values as strings (`"3"`), and `typeof "3" === 'number'` is false, so the new options would silently fall back to 0 unless the user hand-edited `settings.json` with unquoted numbers. Accept numeric strings via a small coercion helper. Companion to the admin UI fields in SignalK/signalk-server#2694.
3. **`write uniqueNumber to addressClaim.fields, not top-level`** — long-standing latent bug: the previous code set `this.addressClaim.uniqueNumber = uniqueNumber` (or the camelcase-string-name property `'Unique Number'`) as a top-level property of the PGN_60928 object. PGN_60928 stores its actual NMEA field values under `.fields`, so the encoder ignored the override and serialized every claim with the all-ones unique-number sentinel (`0x1FFFFF` = 2097151). Some N2K analyzers (Maretron) treat that value as "factory default / unconfigured" and hide the device from their device list. Affected every canboatjs-based provider, not just the new N2kIpGateway — surfaced once we started reading values off `addressClaim.fields` in the new instance-options test. Moving the assignment onto `.fields.uniqueNumber` makes it participate in PGN encoding; the wire now carries the persisted (or supplied) unique number.

## Test plan

- [x] `npm run format` clean
- [x] `npm run build` clean
- [x] `npm test` — 53 tests pass, including 9 new `n2kDevice.test.ts` cases covering: default zero instances, combined `deviceInstance` splitting (5 → lower=5/upper=0, 12 → lower=4/upper=1, 255 → lower=7/upper=31), explicit lower/upper overrides, systemInstance pass-through, numeric-string coercion, non-numeric fallback to 0, and `uniqueNumber` landing on `.fields`.
- [x] **Live tested on a real NMEA 2000 bus.** After this change, the Maretron N2K analyzer reports our device as `signalk-server (0x65) 1150522` with `Device Instance Lower: 3 / Upper: 0`, `System Instance: 3`, `Industry Group: Marine`, `Device Class: Internetwork Device`, `Device Function: 130 (PC Gateway)` — all matching the configured values. Before the fix the wire showed `FFFFFF7C 00 82 33 C0` (sentinel unique + zero instances regardless of config).

## Relationship to other open PRs

- canboat/canboatjs#437 (the N2kIpGateway source) used to bundle these three commits; this PR is the split. #437 has been force-pushed to drop them.
- SignalK/signalk-server#2694 (signalk-server wiring + admin UI) adds Device Instance and System Instance inputs that depend on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * N2K devices support configurable device instance values with automatic splitting, explicit overrides, and numeric-string input handling with validation and safe fallbacks.

* **Bug Fixes**
  * Address-claim unique number handling corrected so devices advertise the intended identity when claiming addresses.

* **Tests**
  * Added comprehensive unit tests covering address-claim option mapping, instance parsing, overrides, and edge-case fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->