### PR TITLE
feat: auto-discover Maretron IPG100 on the LAN

### DIFF
--- a/lib/discovery.test.ts
+++ b/lib/discovery.test.ts
@@ -1,0 +1,92 @@
+import dgram from 'dgram'
+import { EventEmitter } from 'events'
+import { discover, isMaretronAnnounce } from './discovery'
+
+// A real 34-byte IPG100 announce captured off the wire: the ASCII string
+// "IPG, return ping ACK\0" followed by a binary flags/identifier tail.
+const IPG_ANNOUNCE = Buffer.from(
+  '4950472c2072657475726e2070696e672041434b000100000000dcff7b24a0bd1800',
+  'hex'
+)
+
+describe('isMaretronAnnounce', () => {
+  test('matches a real IPG100 announce frame', () => {
+    expect(isMaretronAnnounce(IPG_ANNOUNCE)).toBe(true)
+  })
+
+  test('matches the prefix regardless of the binary tail', () => {
+    expect(isMaretronAnnounce(Buffer.from('IPG, return ping ACK'))).toBe(true)
+  })
+
+  test('rejects YDRAW and other unrelated traffic', () => {
+    expect(isMaretronAnnounce(Buffer.from('$YDRAW'))).toBe(false)
+    expect(isMaretronAnnounce(Buffer.from('CONNECT\t""'))).toBe(false)
+    expect(isMaretronAnnounce(Buffer.alloc(0))).toBe(false)
+    expect(isMaretronAnnounce(Buffer.from('IPG'))).toBe(false)
+  })
+})
+
+describe('discover — Maretron IPG', () => {
+  function makeApp(): EventEmitter & { config: any } {
+    const app = new EventEmitter() as EventEmitter & { config: any }
+    app.config = { settings: { pipedProviders: [] } }
+    return app
+  }
+
+  test('emits a maretron-ipg-canboatjs provider on receiving an announce', (done) => {
+    const app = makeApp()
+    app.on('discovered', (provider: any) => {
+      try {
+        const subOptions = provider.pipeElements[0].options.subOptions
+        expect(subOptions.type).toBe('maretron-ipg-canboatjs')
+        expect(subOptions.host).toBe('127.0.0.1')
+        expect(subOptions.port).toBe('6543')
+        expect(provider.id).toBe('Maretron-IPG-127.0.0.1')
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+
+    discover(app)
+
+    // Give the discovery socket a moment to bind before announcing.
+    setTimeout(() => {
+      const sender = dgram.createSocket('udp4')
+      sender.send(IPG_ANNOUNCE, 65499, '127.0.0.1', () => sender.close())
+    }, 200)
+  })
+
+  test('does not re-discover when a maretron-ipg provider already exists', (done) => {
+    const app = makeApp()
+    app.config.settings.pipedProviders = [
+      {
+        pipeElements: [
+          {
+            type: 'providers/simple',
+            options: {
+              type: 'NMEA2000',
+              subOptions: { type: 'maretron-ipg-canboatjs', host: '10.0.0.5' }
+            }
+          }
+        ]
+      }
+    ]
+    let emitted = false
+    app.on('discovered', () => {
+      emitted = true
+    })
+
+    discover(app)
+
+    setTimeout(() => {
+      const sender = dgram.createSocket('udp4')
+      sender.send(IPG_ANNOUNCE, 65499, '127.0.0.1', () => sender.close())
+    }, 200)
+
+    setTimeout(() => {
+      expect(emitted).toBe(false)
+      done()
+    }, 600)
+  })
+})

--- a/lib/discovery.ts
+++ b/lib/discovery.ts
@@ -37,7 +37,7 @@ const DISCOVERY_TIMEOUT_MS = 30000
 export function isMaretronAnnounce(buffer: Buffer): boolean {
   return (
     buffer.length >= MARETRON_ANNOUNCE_PREFIX.length &&
-    buffer.toString('latin1', 0, MARETRON_ANNOUNCE_PREFIX.length) ===
+    buffer.toString('ascii', 0, MARETRON_ANNOUNCE_PREFIX.length) ===
       MARETRON_ANNOUNCE_PREFIX
   )
 }

--- a/lib/discovery.ts
+++ b/lib/discovery.ts
@@ -16,11 +16,105 @@
 
 import { createDebug } from './utilities'
 import { isYDRAW } from './stringMsg'
+import { IPG_PORT } from './maretron-ipg'
 import dgram from 'dgram'
 
 const debug = createDebug('canboatjs:discovery')
 
+// The Maretron IPG100 advertises itself on the LAN with an unsolicited UDP
+// broadcast to port 65499 every ~10 s. The 34-byte payload begins with the
+// ASCII string "IPG, return ping ACK\0" followed by a binary tail (flags +
+// device identifier). We listen for one such frame, take the announcing
+// host's IP as the connect target, and emit a streaming
+// `maretron-ipg-canboatjs` provider on the IPG's TCP control port.
+const MARETRON_ANNOUNCE_PORT = 65499
+const MARETRON_ANNOUNCE_PREFIX = 'IPG, return ping ACK'
+const DISCOVERY_TIMEOUT_MS = 30000
+
+// Match on the leading ASCII prefix only — the binary tail varies by device
+// and firmware, but the prefix is constant and specific enough not to claim
+// unrelated traffic that happens to land on 65499.
+export function isMaretronAnnounce(buffer: Buffer): boolean {
+  return (
+    buffer.length >= MARETRON_ANNOUNCE_PREFIX.length &&
+    buffer.toString('latin1', 0, MARETRON_ANNOUNCE_PREFIX.length) ===
+      MARETRON_ANNOUNCE_PREFIX
+  )
+}
+
+function discoverMaretronIPG(app: any) {
+  const port = String(IPG_PORT)
+  const exists = app.config.settings.pipedProviders.find((provider: any) => {
+    return (
+      provider.pipeElements &&
+      provider.pipeElements.length === 1 &&
+      provider.pipeElements[0].type == 'providers/simple' &&
+      provider.pipeElements[0].options &&
+      provider.pipeElements[0].options.type === 'NMEA2000' &&
+      provider.pipeElements[0].options.subOptions.type ===
+        'maretron-ipg-canboatjs'
+    )
+  })
+
+  if (exists) return
+
+  const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+  let done = false
+  socket.on('message', (buffer: Buffer, remote: any) => {
+    if (done) return
+    if (!isMaretronAnnounce(buffer)) return
+    done = true
+    socket.close()
+    const host = remote.address
+    debug('found Maretron IPG at %s (announce on port %d)', host, remote.port)
+    app.emit('discovered', {
+      id: `Maretron-IPG-${host}`,
+      pipeElements: [
+        {
+          type: 'providers/simple',
+          options: {
+            logging: false,
+            type: 'NMEA2000',
+            subOptions: {
+              type: 'maretron-ipg-canboatjs',
+              host,
+              port
+            }
+          }
+        }
+      ]
+    })
+  })
+  socket.on('error', (error: any) => {
+    debug(error)
+  })
+  socket.on('close', () => {
+    debug('close')
+  })
+  debug(
+    'looking for a Maretron IPG broadcasting on UDP port %d',
+    MARETRON_ANNOUNCE_PORT
+  )
+  try {
+    socket.bind(MARETRON_ANNOUNCE_PORT)
+  } catch (ex) {
+    debug(ex)
+  }
+  const timer = setTimeout(() => {
+    if (!done) {
+      socket.close()
+    }
+  }, DISCOVERY_TIMEOUT_MS)
+  // Don't let the discovery window hold the host process open: SignalK's
+  // shutdown (and jest) should be free to exit before the 30 s timeout.
+  if (timer.unref) timer.unref()
+}
+
 export function discover(app: any) {
+  if (app.config.settings.pipedProviders) {
+    discoverMaretronIPG(app)
+  }
+
   if (app.config.settings.pipedProviders) {
     const exists = app.config.settings.pipedProviders.find((provider: any) => {
       return (


### PR DESCRIPTION
## Summary

The Maretron IPG100 broadcasts an unsolicited UDP announce to port 65499 every ~10 s. This adds a discoverer to `discovery.ts` that listens for it, takes the announcing host's IP, and emits a `maretron-ipg-canboatjs` provider on the IPG's TCP control port (6543) — so the gateway appears at the top of the Connections page automatically, the same way the YDWG02 over UDP already does.

## How

- New `discoverMaretronIPG()` in `lib/discovery.ts`, called from `discover()`, mirroring the existing YDWG02-UDP pattern.
- Binds UDP 65499 for a 30 s window and matches the announce by its leading ASCII prefix `IPG, return ping ACK` (the 34-byte payload's binary tail varies by device/firmware, the prefix is constant).
- Skips discovery when a `maretron-ipg-canboatjs` provider is already configured. Discovery timer is `unref()`'d so it never holds the host process open.
- The connect port comes from `IPG_PORT` in `maretron-ipg.ts`. No password is set on the discovered entry, which matches a stock IPG (the user can add one afterwards).

## Tested

- Validated end-to-end against a real Maretron IPG100 on the LAN: `discover()` caught the live 10 s broadcast and emitted `{ type: maretron-ipg-canboatjs, host: <ipg-ip>, port: 6543 }`.
- Unit tests use the real captured 34-byte announce as the fixture (prefix match, live UDP round-trip emitting the provider, and the no-re-discover-when-configured case).
- `npm run format`, `npm run build`, `npm test` (jest + mocha): all green.

## Pairs with

The Signal K Server connection-type wiring that consumes this discovered provider: SignalK/signalk-server#2703.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic discovery of Maretron IPG devices via network broadcasts
  * Prevents duplicate provider configurations when re-discovering devices
  * Discovery now respects a short timeout to avoid lingering network listeners

* **Tests**
  * Added unit and integration tests covering announce detection, discovery emissions, and duplicate-suppression behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->