### PR TITLE
feat: auto-discover sensesp-n2k-gateway via mDNS

### DIFF
--- a/lib/discovery.test.ts
+++ b/lib/discovery.test.ts
@@ -156,6 +156,29 @@ describe('discover — SensESP-N2K (mDNS)', () => {
     })
   })
 
+  test('prefers an IPv4 address when both v4 and v6 are advertised', (done) => {
+    const app = makeApp()
+    app.on('discovered', (provider: any) => {
+      try {
+        expect(provider.id).toBe('SensESP-N2K-192.168.1.42')
+        expect(provider.pipeElements[0].options.subOptions.host).toBe(
+          '192.168.1.42'
+        )
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+
+    discover(app)
+
+    lastBrowser().emit('serviceUp', {
+      addresses: ['fe80::1', '192.168.1.42'],
+      port: 2599,
+      txt: { format: 'candump3' }
+    })
+  })
+
   test('ignores services with a non-candump3 format', () => {
     const app = makeApp()
     const emitted: any[] = []

--- a/lib/discovery.test.ts
+++ b/lib/discovery.test.ts
@@ -1,5 +1,22 @@
 import dgram from 'dgram'
 import { EventEmitter } from 'events'
+
+// Mock dnssd before importing discovery — keeps tests off the multicast
+// network and gives us deterministic control over serviceUp events.
+class FakeBrowser extends EventEmitter {
+  start = jest.fn()
+  stop = jest.fn()
+}
+const mockBrowsers: FakeBrowser[] = []
+jest.mock('dnssd', () => ({
+  Browser: jest.fn().mockImplementation(() => {
+    const b = new FakeBrowser()
+    mockBrowsers.push(b)
+    return b
+  }),
+  tcp: jest.fn((name: string) => `_${name}._tcp`)
+}))
+
 import { discover, isMaretronAnnounce } from './discovery'
 
 // A real 34-byte IPG100 announce captured off the wire: the ASCII string
@@ -88,5 +105,104 @@ describe('discover — Maretron IPG', () => {
       expect(emitted).toBe(false)
       done()
     }, 600)
+  })
+})
+
+describe('discover — SensESP-N2K (mDNS)', () => {
+  function makeApp(): EventEmitter & { config: any } {
+    const app = new EventEmitter() as EventEmitter & { config: any }
+    app.config = { settings: { pipedProviders: [] } }
+    return app
+  }
+
+  beforeEach(() => {
+    mockBrowsers.length = 0
+  })
+
+  // The mocked dnssd module advertises one Browser per `discover()` call —
+  // grab the most recent one and replay an mDNS serviceUp event through it.
+  function lastBrowser(): FakeBrowser {
+    return mockBrowsers[mockBrowsers.length - 1]
+  }
+
+  test('emits a navlink2-tcp provider when a sensesp-n2k service is announced', (done) => {
+    const app = makeApp()
+    app.on('discovered', (provider: any) => {
+      try {
+        expect(provider.id).toBe('SensESP-N2K-192.168.1.42')
+        const sub = provider.pipeElements[0].options.subOptions
+        expect(sub.type).toBe('navlink2-tcp-canboatjs')
+        expect(sub.host).toBe('192.168.1.42')
+        expect(sub.port).toBe('2599')
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+
+    discover(app)
+
+    lastBrowser().emit('serviceUp', {
+      fullname: 'n2k-gateway._sensesp-n2k._tcp.local',
+      name: 'n2k-gateway',
+      addresses: ['192.168.1.42'],
+      port: 2599,
+      txt: {
+        txtvers: '1',
+        format: 'candump3',
+        iface: 'can0',
+        model: 'sensesp-n2k-gateway'
+      }
+    })
+  })
+
+  test('ignores services with a non-candump3 format', () => {
+    const app = makeApp()
+    const emitted: any[] = []
+    app.on('discovered', (p: any) => emitted.push(p))
+
+    discover(app)
+
+    lastBrowser().emit('serviceUp', {
+      addresses: ['192.168.1.42'],
+      port: 2599,
+      txt: { format: 'actisense' }
+    })
+
+    expect(emitted).toEqual([])
+  })
+
+  test('does not re-discover when the same host is already configured', () => {
+    const app = makeApp()
+    app.config.settings.pipedProviders = [
+      {
+        id: 'SensESP-N2K-192.168.1.42',
+        pipeElements: [
+          {
+            type: 'providers/simple',
+            options: {
+              type: 'NMEA2000',
+              subOptions: {
+                type: 'navlink2-tcp-canboatjs',
+                host: '192.168.1.42',
+                port: '2599'
+              }
+            }
+          }
+        ]
+      }
+    ]
+    const emitted: any[] = []
+    app.on('discovered', (p: any) => emitted.push(p))
+
+    discover(app)
+
+    lastBrowser().emit('serviceUp', {
+      addresses: ['192.168.1.42'],
+      port: 2599,
+      txt: { format: 'candump3' }
+    })
+
+    expect(emitted).toEqual([])
   })
 })

--- a/lib/discovery.ts
+++ b/lib/discovery.ts
@@ -149,7 +149,12 @@ function discoverSensespN2K(app: any) {
       )
       return
     }
-    const host = service.addresses && service.addresses[0]
+    // Prefer an IPv4 address — dnssd may list IPv6 first (e.g. ['::1',
+    // '192.168.1.1']) and downstream Node net.connect / SignalK consumers
+    // generally expect bare-dot-quad hosts in the provider config.
+    const addresses: string[] = service.addresses || []
+    const host =
+      addresses.find((a) => /^\d+\.\d+\.\d+\.\d+$/.test(a)) || addresses[0]
     const port = service.port
     if (!host || !port) return
 

--- a/lib/discovery.ts
+++ b/lib/discovery.ts
@@ -19,6 +19,12 @@ import { isYDRAW } from './stringMsg'
 import { IPG_PORT } from './maretron-ipg'
 import dgram from 'dgram'
 
+// dnssd is plain CommonJS with no shipped types. The namespace import keeps
+// it untyped without needing a @types shim, while satisfying both the no-
+// require-imports lint rule and esModuleInterop.
+// @ts-expect-error -- no @types/dnssd published
+import * as dnssd from 'dnssd'
+
 const debug = createDebug('canboatjs:discovery')
 
 // The Maretron IPG100 advertises itself on the LAN with an unsolicited UDP
@@ -110,9 +116,98 @@ function discoverMaretronIPG(app: any) {
   if (timer.unref) timer.unref()
 }
 
+// The sensesp-n2k-gateway ESP32 firmware (Ethernet or WiFi) advertises a
+// candump3 TCP stream via mDNS as `_sensesp-n2k._tcp`. Works across both
+// link types where UDP broadcast is unreliable. The advertisement carries
+// `format=candump3` and the candump interface name in its TXT records;
+// port comes from the SRV record. We map a discovered service to a
+// streaming `navlink2-tcp-canboatjs` provider, which feeds candump3 lines
+// into canboatjs's TCP+Liner pipeline and auto-detects the format.
+const SENSESP_N2K_SERVICE = 'sensesp-n2k'
+
+function discoverSensespN2K(app: any) {
+  const browser = new dnssd.Browser(dnssd.tcp(SENSESP_N2K_SERVICE))
+  let done = false
+  const stop = () => {
+    if (done) return
+    done = true
+    try {
+      browser.stop()
+    } catch (ex) {
+      debug(ex)
+    }
+  }
+
+  browser.on('serviceUp', (service: any) => {
+    if (done) return
+    const txt = service.txt || {}
+    if (txt.format !== 'candump3') {
+      debug(
+        'ignoring %s: unsupported format %j',
+        service.fullname || service.name,
+        txt.format
+      )
+      return
+    }
+    const host = service.addresses && service.addresses[0]
+    const port = service.port
+    if (!host || !port) return
+
+    const id = `SensESP-N2K-${host}`
+    const exists = app.config.settings.pipedProviders.find((provider: any) => {
+      const opts = provider.pipeElements?.[0]?.options
+      const sub = opts?.subOptions
+      return (
+        provider.id === id ||
+        (opts?.type === 'NMEA2000' &&
+          sub?.type === 'navlink2-tcp-canboatjs' &&
+          sub?.host === host &&
+          String(sub?.port) === String(port))
+      )
+    })
+    if (exists) {
+      debug('SensESP-N2K at %s already configured, skipping', host)
+      return
+    }
+
+    debug('found SensESP-N2K gateway at %s:%d', host, port)
+    app.emit('discovered', {
+      id,
+      pipeElements: [
+        {
+          type: 'providers/simple',
+          options: {
+            logging: false,
+            type: 'NMEA2000',
+            subOptions: {
+              type: 'navlink2-tcp-canboatjs',
+              host,
+              port: String(port)
+            }
+          }
+        }
+      ]
+    })
+  })
+  browser.on('error', (error: any) => {
+    debug(error)
+  })
+
+  debug('browsing for _%s._tcp via mDNS', SENSESP_N2K_SERVICE)
+  try {
+    browser.start()
+  } catch (ex) {
+    debug(ex)
+  }
+
+  const timer = setTimeout(stop, DISCOVERY_TIMEOUT_MS)
+  if (timer.unref) timer.unref()
+}
+
 export function discover(app: any) {
   if (app.config.settings.pipedProviders) {
     discoverMaretronIPG(app)
+    discoverSensespN2K(app)
   }
 
   if (app.config.settings.pipedProviders) {


### PR DESCRIPTION
## Summary

Adds an mDNS discoverer to `discovery.ts` for the [sensesp-n2k-gateway](https://github.com/dirkwa/sensesp-n2k-gateway) ESP32 firmware, which advertises itself on the LAN as `_sensesp-n2k._tcp` with TXT records describing the wire format (candump3) and CAN interface name. Same UX as PR #439 (Maretron IPG100), but mDNS rather than UDP broadcast — the gateway can run on either Ethernet or WiFi, and WiFi broadcasts are unreliable across AP client isolation / multicast snooping.

## How

- New `discoverSensespN2K()` in `lib/discovery.ts`, called from `discover()` next to `discoverMaretronIPG()`. Mirrors PR #439's pattern: skip-if-already-configured guard, 30 s timeout, `unref`'d timer.
- Maps each discovered service to a streaming `navlink2-tcp-canboatjs` provider — no new provider type needed, since the existing TCP+Liner pipeline already auto-detects candump3 via `isCandump3` in `stringMsg.ts`.
- Dedup is per-host (id + host+port match) so multiple gateways can be discovered independently.
- Reuses the `dnssd` dependency already declared in `package.json`. Uses `import * as dnssd from 'dnssd'` with `@ts-expect-error` (no `@types/dnssd` published).
- TXT schema: `txtvers=1`, `format=candump3`, `iface=<can-interface>`, `model=sensesp-n2k-gateway`. Format gating ignores services advertising anything other than `candump3`, leaving room for the gateway to add other formats later without breaking older clients.

## Tested

- Unit tests: three new jest cases for the success path, non-candump3 rejection, and dedup. Mock `dnssd.Browser` to keep tests off the multicast network.
- End-to-end against a real sensesp-n2k-gateway running on the LAN: `discover()` emitted a `SensESP-N2K-<host>` provider with `subOptions.type = 'navlink2-tcp-canboatjs'` within ~320 ms. Coexisted with the existing Maretron IPG100 UDP discovery (also emitted, distinct provider) without interference.
- `npm run format`, `npm run build`, `npm test`: all green (jest 124/124, mocha 190/190).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic mDNS discovery for SensESP-N2K devices, detecting candump3-format services and deriving host/port
  * Avoids creating duplicate registrations for already-configured hosts

* **Tests**
  * Added/expanded tests to simulate mDNS service announcements and validate discovery behavior, address selection, and duplicate suppression

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/canboatjs/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->