### PR TITLE
feat(discovery): require the 0x01 flag and actively solicit the Maretron IPG

### DIFF
--- a/lib/discovery.test.ts
+++ b/lib/discovery.test.ts
@@ -1,4 +1,3 @@
-import dgram from 'dgram'
 import { EventEmitter } from 'events'
 
 // Mock dnssd before importing discovery — keeps tests off the multicast
@@ -17,12 +16,67 @@ jest.mock('dnssd', () => ({
   tcp: jest.fn((name: string) => `_${name}._tcp`)
 }))
 
-import { discover, isMaretronAnnounce } from './discovery'
+// Mock dgram too, so discover()'s UDP listeners never touch the real network.
+// bind() resolves immediately; send() is a no-op (no broadcast onto the LAN —
+// this is what keeps a live IPG on the test host from polluting these tests).
+// Created sockets are tracked so a test can replay an inbound frame by emitting
+// a 'message' event on the listener.
+class FakeUdpSocket extends EventEmitter {
+  setBroadcast = jest.fn()
+  send = jest.fn(
+    (_buf: Buffer, _port: number, _addr: string, cb?: (e?: Error) => void) => {
+      if (cb) cb()
+    }
+  )
+  bind = jest.fn((portOrCb?: any, cb?: () => void) => {
+    const done = typeof portOrCb === 'function' ? portOrCb : cb
+    if (done) done()
+    return this
+  })
+  close = jest.fn()
+}
+const mockUdpSockets: FakeUdpSocket[] = []
+jest.mock('dgram', () => ({
+  createSocket: jest.fn(() => {
+    const s = new FakeUdpSocket()
+    mockUdpSockets.push(s)
+    return s
+  })
+}))
 
-// A real 34-byte IPG100 announce captured off the wire: the ASCII string
-// "IPG, return ping ACK\0" followed by a binary flags/identifier tail.
+import {
+  discover,
+  isMaretronAnnounce,
+  buildMaretronRequest,
+  sendMaretronRequest
+} from './discovery'
+
+// A real 34-byte IPG100 announce/response captured off the wire: the ASCII
+// string "IPG, return ping ACK\0" followed by the 0x01 discriminator and a
+// binary flags/identifier tail.
 const IPG_ANNOUNCE = Buffer.from(
   '4950472c2072657475726e2070696e672041434b000100000000dcff7b24a0bd1800',
+  'hex'
+)
+
+// The 22-byte request frame other hosts (e.g. Maretron N2KAnalyzer) broadcast:
+// the same prefix + NUL + a 0x00 discriminator, with no device tail.
+const IPG_REQUEST = Buffer.from(
+  '4950472c2072657475726e2070696e672041434b0000',
+  'hex'
+)
+
+// Full-length (34-byte) negative fixtures derived from IPG_ANNOUNCE by flipping
+// a single byte, so each clears the length check and exercises exactly the one
+// guard it is named for (rather than being rejected early on length):
+//   - REQUEST_FLAG: byte 21 is 0x00 (request) instead of 0x01 → discriminator guard
+//   - BAD_SEPARATOR: byte 20 is 0xff instead of the NUL 0x00  → NUL-separator guard
+const IPG_REQUEST_FLAG_FULL = Buffer.from(
+  '4950472c2072657475726e2070696e672041434b000000000000dcff7b24a0bd1800',
+  'hex'
+)
+const IPG_BAD_SEPARATOR_FULL = Buffer.from(
+  '4950472c2072657475726e2070696e672041434bff0100000000dcff7b24a0bd1800',
   'hex'
 )
 
@@ -31,8 +85,34 @@ describe('isMaretronAnnounce', () => {
     expect(isMaretronAnnounce(IPG_ANNOUNCE)).toBe(true)
   })
 
-  test('matches the prefix regardless of the binary tail', () => {
-    expect(isMaretronAnnounce(Buffer.from('IPG, return ping ACK'))).toBe(true)
+  test('rejects a truncated 0x01 frame missing the 12-byte body', () => {
+    // Prefix + NUL + 0x01 but only 22 bytes — a genuine ACK is 34 bytes, so a
+    // header-only frame (truncated or spoofed) must not match.
+    expect(
+      isMaretronAnnounce(
+        Buffer.from('4950472c2072657475726e2070696e672041434b0001', 'hex')
+      )
+    ).toBe(false)
+  })
+
+  test('rejects the 22-byte 0x00 request frame other hosts broadcast', () => {
+    // The actual on-the-wire request: 22 bytes, 0x00 flag. Rejected (on length).
+    expect(isMaretronAnnounce(IPG_REQUEST)).toBe(false)
+  })
+
+  test('rejects a full-length frame whose flag byte is the 0x00 request flag', () => {
+    // 34 bytes, so the discriminator guard (not length) is what rejects it.
+    expect(isMaretronAnnounce(IPG_REQUEST_FLAG_FULL)).toBe(false)
+  })
+
+  test('rejects a bare prefix with no discriminator', () => {
+    expect(isMaretronAnnounce(Buffer.from('IPG, return ping ACK'))).toBe(false)
+  })
+
+  test('rejects a full-length frame with a non-NUL separator at offset 20', () => {
+    // 34 bytes with 0xff at offset 20 and 0x01 at 21, so the NUL-separator
+    // guard (not length) is what rejects it.
+    expect(isMaretronAnnounce(IPG_BAD_SEPARATOR_FULL)).toBe(false)
   })
 
   test('rejects YDRAW and other unrelated traffic', () => {
@@ -43,6 +123,87 @@ describe('isMaretronAnnounce', () => {
   })
 })
 
+describe('buildMaretronRequest', () => {
+  test('produces the exact 22-byte request frame', () => {
+    expect(buildMaretronRequest()).toEqual(IPG_REQUEST)
+  })
+
+  test('carries the 0x00 request discriminator and never self-triggers', () => {
+    const req = buildMaretronRequest()
+    expect(req[21]).toBe(0x00)
+    expect(isMaretronAnnounce(req)).toBe(false)
+  })
+})
+
+describe('sendMaretronRequest', () => {
+  class FakeSocket extends EventEmitter {
+    send = jest.fn(
+      (
+        _buf: Buffer,
+        _port: number,
+        _addr: string,
+        cb?: (e?: Error) => void
+      ) => {
+        if (cb) cb()
+      }
+    )
+  }
+
+  test('broadcasts the request frame to port 65499 on the given socket', () => {
+    const fake = new FakeSocket()
+    sendMaretronRequest(fake as any, () => false)
+    expect(fake.send).toHaveBeenCalled()
+    const [buf, port, addr] = fake.send.mock.calls[0]
+    expect(Buffer.from(buf).equals(buildMaretronRequest())).toBe(true)
+    expect(port).toBe(65499)
+    expect(addr).toBe('255.255.255.255')
+  })
+
+  test('does not send when discovery is already done', () => {
+    const fake = new FakeSocket()
+    sendMaretronRequest(fake as any, () => true)
+    expect(fake.send).not.toHaveBeenCalled()
+  })
+
+  test('bursts the request on its retry schedule until all timers fire', () => {
+    jest.useFakeTimers()
+    try {
+      const fake = new FakeSocket()
+      sendMaretronRequest(fake as any, () => false)
+      // One immediate send before any timer fires.
+      expect(fake.send).toHaveBeenCalledTimes(1)
+      // Draining the burst timers produces the remaining retry sends.
+      jest.runOnlyPendingTimers()
+      expect(fake.send.mock.calls.length).toBeGreaterThan(1)
+      // Every send targets port 65499 with the request frame.
+      for (const [buf, port, addr] of fake.send.mock.calls) {
+        expect(Buffer.from(buf).equals(buildMaretronRequest())).toBe(true)
+        expect(port).toBe(65499)
+        expect(addr).toBe('255.255.255.255')
+      }
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('stops bursting once a reply has been handled', () => {
+    jest.useFakeTimers()
+    try {
+      const fake = new FakeSocket()
+      // Flip to "done" right after the immediate send, before any retry fires.
+      let done = false
+      sendMaretronRequest(fake as any, () => done)
+      expect(fake.send).toHaveBeenCalledTimes(1)
+      done = true
+      jest.runOnlyPendingTimers()
+      // No further sends after isDone() returns true.
+      expect(fake.send).toHaveBeenCalledTimes(1)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+})
+
 describe('discover — Maretron IPG', () => {
   function makeApp(): EventEmitter & { config: any } {
     const app = new EventEmitter() as EventEmitter & { config: any }
@@ -50,31 +211,55 @@ describe('discover — Maretron IPG', () => {
     return app
   }
 
-  test('emits a maretron-ipg-canboatjs provider on receiving an announce', (done) => {
-    const app = makeApp()
-    app.on('discovered', (provider: any) => {
-      try {
-        const subOptions = provider.pipeElements[0].options.subOptions
-        expect(subOptions.type).toBe('maretron-ipg-canboatjs')
-        expect(subOptions.host).toBe('127.0.0.1')
-        expect(subOptions.port).toBe('6543')
-        expect(provider.id).toBe('Maretron-IPG-127.0.0.1')
-        done()
-      } catch (err) {
-        done(err)
-      }
-    })
-
-    discover(app)
-
-    // Give the discovery socket a moment to bind before announcing.
-    setTimeout(() => {
-      const sender = dgram.createSocket('udp4')
-      sender.send(IPG_ANNOUNCE, 65499, '127.0.0.1', () => sender.close())
-    }, 200)
+  beforeEach(() => {
+    mockUdpSockets.length = 0
   })
 
-  test('does not re-discover when a maretron-ipg provider already exists', (done) => {
+  // The first socket created by discover() is the Maretron listener; replay an
+  // inbound UDP frame on it by emitting a 'message' event (host, port).
+  function announceTo(buffer: Buffer, address = '192.168.0.179') {
+    const listener = mockUdpSockets[0]
+    listener.emit('message', buffer, { address, port: 65499 })
+  }
+
+  test('emits a maretron-ipg-canboatjs provider on receiving an announce', () => {
+    const app = makeApp()
+    const providers: any[] = []
+    app.on('discovered', (p: any) => providers.push(p))
+
+    discover(app)
+    announceTo(IPG_ANNOUNCE, '192.168.0.179')
+
+    const maretron = providers.find(
+      (p) =>
+        p.pipeElements[0].options.subOptions.type === 'maretron-ipg-canboatjs'
+    )
+    expect(maretron).toBeDefined()
+    const sub = maretron.pipeElements[0].options.subOptions
+    expect(sub.host).toBe('192.168.0.179')
+    expect(sub.port).toBe('6543')
+    expect(maretron.id).toBe('Maretron-IPG-192.168.0.179')
+  })
+
+  test('ignores a 0x00 request frame from another host', () => {
+    const app = makeApp()
+    const providers: any[] = []
+    app.on('discovered', (p: any) => providers.push(p))
+
+    discover(app)
+    // A request frame (0x00) arriving from some other host must not be
+    // mis-discovered as the IPG.
+    announceTo(IPG_REQUEST, '10.0.0.99')
+
+    expect(
+      providers.find(
+        (p) =>
+          p.pipeElements[0].options.subOptions.type === 'maretron-ipg-canboatjs'
+      )
+    ).toBeUndefined()
+  })
+
+  test('does not re-discover when a maretron-ipg provider already exists', () => {
     const app = makeApp()
     app.config.settings.pipedProviders = [
       {
@@ -95,16 +280,10 @@ describe('discover — Maretron IPG', () => {
     })
 
     discover(app)
-
-    setTimeout(() => {
-      const sender = dgram.createSocket('udp4')
-      sender.send(IPG_ANNOUNCE, 65499, '127.0.0.1', () => sender.close())
-    }, 200)
-
-    setTimeout(() => {
-      expect(emitted).toBe(false)
-      done()
-    }, 600)
+    // The existing provider short-circuits the Maretron listener; even if a
+    // frame did arrive it must not emit.
+    if (mockUdpSockets.length > 0) announceTo(IPG_ANNOUNCE)
+    expect(emitted).toBe(false)
   })
 })
 

--- a/lib/discovery.ts
+++ b/lib/discovery.ts
@@ -29,23 +29,108 @@ const debug = createDebug('canboatjs:discovery')
 
 // The Maretron IPG100 advertises itself on the LAN with an unsolicited UDP
 // broadcast to port 65499 every ~10 s. The 34-byte payload begins with the
-// ASCII string "IPG, return ping ACK\0" followed by a binary tail (flags +
-// device identifier). We listen for one such frame, take the announcing
+// ASCII string "IPG, return ping ACK\0" followed by a 0x01 discriminator and
+// a binary device tail. We listen for one such frame, take the announcing
 // host's IP as the connect target, and emit a streaming
-// `maretron-ipg-canboatjs` provider on the IPG's TCP control port.
-const MARETRON_ANNOUNCE_PORT = 65499
-const MARETRON_ANNOUNCE_PREFIX = 'IPG, return ping ACK'
+// `maretron-ipg-canboatjs` provider on the IPG's TCP control port. To avoid
+// waiting up to ~10 s for the next announce, we also actively solicit an
+// immediate reply (see sendMaretronRequest).
+//
+// The whole REQ/ACK ping exchange uses port 65499: clients broadcast the
+// request to 65499, and the IPG sends its ACK back to the request packet's
+// source address and port. So we bind one socket to 65499, send the request
+// from it, and read both the solicited reply and the unsolicited announces on
+// that same socket.
+const MARETRON_PORT = 65499
+const MARETRON_ANNOUNCE_PREFIX = 'IPG, return ping ACK' // 20 ASCII bytes
 const DISCOVERY_TIMEOUT_MS = 30000
 
-// Match on the leading ASCII prefix only — the binary tail varies by device
-// and firmware, but the prefix is constant and specific enough not to claim
-// unrelated traffic that happens to land on 65499.
+// Both 65499 ping packets share a 21-byte header: the ASCII prefix followed by
+// a NUL terminator at offset 20. The byte after that (offset 21) is the
+// REQ/ACK flag. Empirically (captured off a live IPG100):
+//   0x01 = a genuine announce/ACK FROM the IPG (34-byte frame: header + a
+//          12-byte body of override IP, service port, product code, serial)
+//   0x00 = a request frame broadcast BY OTHER HOSTS (22-byte frame, no body,
+//          e.g. Maretron N2KAnalyzer). Matching it would mis-discover the
+//          requester's IP as the IPG, so we must reject it.
+const MARETRON_NUL_OFFSET = MARETRON_ANNOUNCE_PREFIX.length // 20
+const MARETRON_DISCRIMINATOR_OFFSET = MARETRON_ANNOUNCE_PREFIX.length + 1 // 21
+const MARETRON_NUL = 0x00
+const MARETRON_RESPONSE_DISCRIMINATOR = 0x01
+const MARETRON_REQUEST_DISCRIMINATOR = 0x00
+// A genuine ACK carries the header plus a 12-byte body (bytes 22–33), so a
+// real announce is 34 bytes. Requiring the full length rejects truncated or
+// spoofed frames that carry only the header and flag.
+const MARETRON_ANNOUNCE_LENGTH = 34
+
+// Active-discovery probe schedule (ms after the socket binds). The IPG often
+// ignores the first packet or two but answers reliably within a few closely
+// spaced retries — so, like Maretron's own N2KAnalyzer, we send a short burst
+// ~100 ms apart. Measured against a live IPG100 this yields a reply within a
+// few hundred ms every time, with no rate-limiting on port 65499. Probing stops
+// as soon as a reply arrives; the unsolicited ~10 s announce is the fallback if
+// every probe is dropped. An immediate send (offset 0) is always done first.
+const MARETRON_PROBE_OFFSETS_MS = [100, 200, 300, 500, 800]
+
+/**
+ * Build the 22-byte active-discovery request frame: the ASCII prefix, a NUL
+ * terminator, and the 0x00 request flag. Broadcasting this to `MARETRON_PORT`
+ * (65499) elicits an immediate ACK that the IPG sends back to the request's
+ * source address and port. Pure and exported so it can be byte-compared against
+ * a captured request frame without touching the network.
+ */
+export function buildMaretronRequest(): Buffer {
+  return Buffer.concat([
+    Buffer.from(MARETRON_ANNOUNCE_PREFIX, 'ascii'),
+    Buffer.from([MARETRON_NUL, MARETRON_REQUEST_DISCRIMINATOR])
+  ])
+}
+
+/**
+ * Return true only for a genuine IPG announce/ACK frame: the full 34-byte
+ * length, the ASCII prefix, the NUL terminator at offset 20, and the 0x01
+ * response flag at offset 21. The 0x00 request frames other hosts broadcast
+ * share the prefix but are 22 bytes with a 0x00 flag, so they are rejected —
+ * as are truncated or spoofed frames that carry only the header and flag.
+ */
 export function isMaretronAnnounce(buffer: Buffer): boolean {
   return (
-    buffer.length >= MARETRON_ANNOUNCE_PREFIX.length &&
+    buffer.length >= MARETRON_ANNOUNCE_LENGTH &&
     buffer.toString('ascii', 0, MARETRON_ANNOUNCE_PREFIX.length) ===
-      MARETRON_ANNOUNCE_PREFIX
+      MARETRON_ANNOUNCE_PREFIX &&
+    buffer[MARETRON_NUL_OFFSET] === MARETRON_NUL &&
+    buffer[MARETRON_DISCRIMINATOR_OFFSET] === MARETRON_RESPONSE_DISCRIMINATOR
   )
+}
+
+/**
+ * Actively solicit an IPG ACK instead of waiting for the next unsolicited
+ * announce. Broadcasts the request frame to `MARETRON_PORT` (65499) from the
+ * caller's already-bound listener `socket` — the IPG sends its ACK back to the
+ * request's source address and port, so it must be sent from the same socket
+ * the caller reads, not a throwaway one. Fire-and-forget: it never reads, it
+ * only sends, on the burst schedule. `isDone()` short-circuits the burst once
+ * the listener has handled a reply. `setBroadcast` must already be enabled on
+ * the socket. Exported for unit testing with a fake socket.
+ */
+export function sendMaretronRequest(
+  socket: dgram.Socket,
+  isDone: () => boolean
+): void {
+  const frame = buildMaretronRequest()
+  const blast = () => {
+    if (isDone()) return
+    socket.send(frame, MARETRON_PORT, '255.255.255.255', (err) => {
+      if (err) debug('probe send failed %s', err)
+    })
+  }
+
+  // Immediate probe, then the ~100 ms-spaced burst retries.
+  blast()
+  for (const offset of MARETRON_PROBE_OFFSETS_MS) {
+    const t = setTimeout(blast, offset)
+    if (t.unref) t.unref()
+  }
 }
 
 function discoverMaretronIPG(app: any) {
@@ -97,12 +182,20 @@ function discoverMaretronIPG(app: any) {
   socket.on('close', () => {
     debug('close')
   })
-  debug(
-    'looking for a Maretron IPG broadcasting on UDP port %d',
-    MARETRON_ANNOUNCE_PORT
-  )
+  debug('looking for a Maretron IPG on UDP port %d', MARETRON_PORT)
   try {
-    socket.bind(MARETRON_ANNOUNCE_PORT)
+    socket.bind(MARETRON_PORT, () => {
+      // Socket is up; actively solicit an immediate ACK instead of waiting up
+      // to ~10 s for the next unsolicited announce. The IPG replies to this
+      // socket's address/port, so we send the request from it and read the
+      // reply on it. Unsolicited announces also arrive here as the fallback.
+      try {
+        socket.setBroadcast(true)
+      } catch (ex) {
+        debug('setBroadcast failed %s', ex)
+      }
+      sendMaretronRequest(socket, () => done)
+    })
   } catch (ex) {
     debug(ex)
   }


### PR DESCRIPTION
Fixes #442. Follow-up to #439, based on traffic captured from a live Maretron IPG100.

## 1. Require the 0x01 flag (fixes a mis-discovery)

The IPG's announce/response is a 34-byte frame: the ASCII prefix `IPG, return ping ACK`, a NUL at offset 20, a `0x01` flag at offset 21, then a 12-byte device body.

The **same prefix** also appears in a 22-byte **request** frame that other tools broadcast to the same port — for example Maretron N2KAnalyzer sends `IPG, return ping ACK\0\0` (a `0x00` flag at offset 21, no body). The previous prefix-only match in `isMaretronAnnounce` treats that request as an IPG announce and discovers the **requester's** IP rather than the IPG.

`isMaretronAnnounce` now requires the full 34-byte length, the NUL separator at offset 20, and the `0x01` flag — accepting the real announce and rejecting request, truncated, and malformed frames. Captured off the wire:

```
announce/response (from IPG):  4950472c2072657475726e2070696e672041434b 00 01 00000000dcff7b24a0bd1800   (34 bytes, flag 0x01)
request (from other hosts):    4950472c2072657475726e2070696e672041434b 00 00                              (22 bytes, flag 0x00)
```

## 2. Actively solicit a reply

Rather than only waiting up to ~10 s for the next unsolicited announce, broadcast the request frame to UDP **65499**. The whole REQ/ACK ping exchange uses 65499, and the IPG sends its ACK back to the request packet's **source address and port** — so we bind one socket to 65499, send the request from it, and read both the solicited reply and the unsolicited announces on that same socket.

There is **no rate-limiting** on the correct port (measured 8/8 replies at 2 s spacing, no cooldown), so — like N2KAnalyzer, which spaces its probes ~100 ms apart — we send a short burst (`[100, 200, 300, 500, 800]` ms) and stop as soon as a reply lands. The passive ~10 s announce remains the guaranteed fallback if every probe is dropped.

## Testing

- Unit tests (no real UDP — `dgram` is mocked, so the `discover()` integration tests never touch the network): the length/NUL/`0x01` discriminator with full-length negative fixtures that each isolate one guard, the request-frame bytes (`buildMaretronRequest`), a self-trigger guard, and `sendMaretronRequest` immediate-send / burst-retry / stop-on-done behavior under fake timers. Full suite green.
- Verified end-to-end against a live IPG100: a request broadcast to `255.255.255.255:65499` elicits the `0x01` ACK on the same socket and `discover()` completes in ~100–800 ms (vs the ~10 s passive wait); a request to `:64999` gets no reply; N2KAnalyzer `0x00` request frames on the wire are no longer mis-discovered.

One existing assertion changed intentionally: a bare 20-byte prefix (no flag) is now rejected, since it can't be a real frame and shares the prefix with the request form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active probing for faster device discovery: immediate probe plus scheduled retries using the same listener socket.

* **Bug Fixes**
  * Much stricter UDP discovery validation to eliminate false positives from truncated or malformed frames.
  * Probing stops promptly once discovery is complete to avoid redundant network traffic.

* **Tests**
  * Expanded unit tests and network-level mocking to cover probe construction, send/retry behavior, addressing, and many negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
