### PR TITLE
fix: handle numeric bitmask values when encoding BITLOOKUP fields

### DIFF
--- a/lib/toPgn.ts
+++ b/lib/toPgn.ts
@@ -515,7 +515,13 @@ export const actisenseToN2KActisenseFormat = _.flow(
   encodeN2KActisense
 )
 
-function bitIsSet(field: Field, index: number, value: string) {
+function bitIsSet(field: Field, index: number, value: any) {
+  // A BITLOOKUP value may arrive either as a raw numeric bitmask or as an
+  // array (or string) of the set enumeration names.
+  if (typeof value === 'number') {
+    return Math.floor(value / Math.pow(2, index)) % 2 === 1
+  }
+
   const enumName = getBitEnumerationName(
     field.LookupBitEnumeration as string,
     index

--- a/test/bitlookup-numeric.js
+++ b/test/bitlookup-numeric.js
@@ -1,0 +1,37 @@
+const chai = require('chai')
+chai.Should()
+const { pgnToActisenseSerialFormat } = require('../dist/index')
+
+// A BITLOOKUP field value may be supplied either as an array of the set
+// enumeration names or as a raw numeric bitmask. The numeric form used to
+// crash the encoder ("value.indexOf is not a function"); both forms must now
+// encode identically. See canboat PR #667 (PGN 127493 made a BITLOOKUP).
+describe('toPgn encodes a numeric BITLOOKUP value', function () {
+  const base = {
+    prio: 2,
+    pgn: 127489, // Engine Parameters, Dynamic (Discrete Status 1 is a BITLOOKUP)
+    dst: 255,
+    src: 16,
+    fields: { instance: 'Single Engine or Dual Engine Port' }
+  }
+
+  const bytes = (pgn) => pgnToActisenseSerialFormat(pgn).split(',').slice(5).join(',')
+
+  it('does not throw on a numeric bitmask', function () {
+    const numeric = { ...base, fields: { ...base.fields, 'Discrete Status 1': 6 } }
+    ;(() => pgnToActisenseSerialFormat(numeric)).should.not.throw()
+  })
+
+  it('numeric bitmask encodes the same as the equivalent name array', function () {
+    // bit 1 = "Over Temperature", bit 2 = "Low Oil Pressure" => 0b110 = 6
+    const numeric = { ...base, fields: { ...base.fields, 'Discrete Status 1': 6 } }
+    const named = {
+      ...base,
+      fields: {
+        ...base.fields,
+        'Discrete Status 1': ['Over Temperature', 'Low Oil Pressure']
+      }
+    }
+    bytes(numeric).should.equal(bytes(named))
+  })
+})

--- a/test/bitlookup-numeric.js
+++ b/test/bitlookup-numeric.js
@@ -15,16 +15,23 @@ describe('toPgn encodes a numeric BITLOOKUP value', function () {
     fields: { instance: 'Single Engine or Dual Engine Port' }
   }
 
-  const bytes = (pgn) => pgnToActisenseSerialFormat(pgn).split(',').slice(5).join(',')
+  const bytes = (pgn) =>
+    pgnToActisenseSerialFormat(pgn).split(',').slice(5).join(',')
 
   it('does not throw on a numeric bitmask', function () {
-    const numeric = { ...base, fields: { ...base.fields, 'Discrete Status 1': 6 } }
+    const numeric = {
+      ...base,
+      fields: { ...base.fields, 'Discrete Status 1': 6 }
+    }
     ;(() => pgnToActisenseSerialFormat(numeric)).should.not.throw()
   })
 
   it('numeric bitmask encodes the same as the equivalent name array', function () {
     // bit 1 = "Over Temperature", bit 2 = "Low Oil Pressure" => 0b110 = 6
-    const numeric = { ...base, fields: { ...base.fields, 'Discrete Status 1': 6 } }
+    const numeric = {
+      ...base,
+      fields: { ...base.fields, 'Discrete Status 1': 6 }
+    }
     const named = {
       ...base,
       fields: {


### PR DESCRIPTION
## Problem

`bitIsSet()` in `toPgn` assumed a BITLOOKUP field value is always an array (or string) of set enumeration names and called `value.indexOf()`. When the value is a **raw numeric bitmask**, encoding throws `TypeError: value.indexOf is not a function`.

Exposed by canboat [PR #667](https://github.com/canboat/canboat/pull/667), which makes PGN 127493 "Discrete Status 1" a BITLOOKUP. The canboat CI then fails in **n2k-signalk**'s `127493_transmission.js`, whose round-trip passes the discrete status as a number (`"Discrete Status 1": 34`).

## Fix

If the value is a number, treat it as a bitmask and test bit `index` directly; the array/string path is unchanged.

## Verification

Reproduced the exact CI scenario (canboat master + #667 → regenerate ts-pgns → build this branch → run n2k-signalk):
- **Without fix:** n2k-signalk 127493 test → `value.indexOf is not a function` (matches CI).
- **With fix:** 127493 test passes; full n2k-signalk 201 passing; canboatjs 136 jest + 192 mocha passing.

Adds `test/bitlookup-numeric.js` (using the existing 127489 engine BITLOOKUP): asserts the numeric form doesn't throw and encodes identically to the equivalent name array. Fails without the fix, passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of BITLOOKUP field values so numeric bitmasks are interpreted correctly.
  * Numeric and named BITLOOKUP inputs now serialize consistently, preventing unexpected errors during conversion.
* **Tests**
  * Added coverage verifying numeric BITLOOKUP values produce the same serialized output as equivalent named values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->