### PR TITLE
fix(fromPgn): decode DYNAMIC_FIELD_VALUE in repeating field sets (e.g. B&G 130824)

### DIFF
--- a/lib/fromPgn.ts
+++ b/lib/fromPgn.ts
@@ -343,7 +343,8 @@ export class Parser extends EventEmitter {
             pgn,
             field,
             bs,
-            fields
+            fields,
+            group
           )
           if (refField) {
             group.parameterId = refField.Id
@@ -403,7 +404,8 @@ export class Parser extends EventEmitter {
               pgn,
               field,
               bs,
-              fields
+              fields,
+              group
             )
             if (refField) {
               group.parameterId = refField.Id
@@ -1114,7 +1116,8 @@ function readField(
   pgn: PGN,
   field: Field,
   bs: BitStream,
-  fields: Field[] | undefined = undefined
+  fields: Field[] | undefined = undefined,
+  data: any = undefined
 ): [any, Field | undefined, ByteMapping | undefined] {
   let value
   let refField: Field | undefined = undefined
@@ -1144,7 +1147,16 @@ function readField(
 
       return [null, undefined, bm]
     }
-    ;[value, refField] = readValue(definition, options, pgn, field, bs, fields)
+    ;[value, refField] = readValue(
+      definition,
+      options,
+      pgn,
+      field,
+      bs,
+      fields,
+      undefined,
+      data
+    )
   }
 
   if (options.includeByteMapping) {
@@ -1263,7 +1275,8 @@ function readValue(
   field: Field,
   bs: BitStream,
   fields: Field[] | undefined,
-  bitLength: number | undefined = undefined
+  bitLength: number | undefined = undefined,
+  data: any = undefined
 ): [any, Field | undefined] {
   if (field.FieldType == 'VARIABLE') {
     return readVariableLengthField(definition, options, pgn, field, bs)
@@ -1274,7 +1287,7 @@ function readValue(
         field.BitLengthVariable &&
         field.FieldType === 'DYNAMIC_FIELD_VALUE'
       ) {
-        bitLength = lookupKeyBitLength(pgn.fields, fields as Field[])
+        bitLength = lookupKeyBitLength(data ?? pgn.fields, fields as Field[])
       } else {
         bitLength = field.BitLength
       }
@@ -1598,6 +1611,17 @@ fieldTypeReaders['BITLOOKUP'] = (pgn, field, bs) => {
 }
 
 function lookupKeyBitLength(data: any, fields: Field[]): number | undefined {
+  // The value's size is carried on the wire by the sibling DYNAMIC_FIELD_LENGTH
+  // field (bytes). Prefer it over the key catalog's nominal Bits so a value of
+  // any length (incl. 0) is consumed exactly, keeping the repeating list in sync.
+  const lengthField = fields.find((f) => f.FieldType === 'DYNAMIC_FIELD_LENGTH')
+  if (lengthField) {
+    const len = data[lengthField.Name] ?? data[lengthField.Id]
+    if (typeof len === 'number') {
+      return len * 8
+    }
+  }
+
   const field = fields.find((field) => field.Name === 'Key')
 
   if (field) {

--- a/lib/fromPgn.ts
+++ b/lib/fromPgn.ts
@@ -343,7 +343,7 @@ export class Parser extends EventEmitter {
             pgn,
             field,
             bs,
-            fields,
+            set1Fields,
             group
           )
           if (refField) {
@@ -404,7 +404,7 @@ export class Parser extends EventEmitter {
               pgn,
               field,
               bs,
-              fields,
+              set2Fields,
               group
             )
             if (refField) {

--- a/test/pgns/130824.js
+++ b/test/pgns/130824.js
@@ -20,5 +20,34 @@ module.exports = [
     },
     input:
       '2016-02-28T19:57:03.931Z,2,130824,24,255,9,89,98,00,00,ff,ff,ff,ff,ff'
+  },
+  {
+    // B&G "key-value data" is a repeating field set of
+    // {key (DYNAMIC_FIELD_KEY), length (DYNAMIC_FIELD_LENGTH), value
+    // (DYNAMIC_FIELD_VALUE)} triplets. The value's bit length is carried by the
+    // sibling length field, so it must be resolved from the current repetition's
+    // accumulated fields, not the top-level pgn.fields. This exercises decoding
+    // the value of each list entry (Target Boat Speed = 80, Polar Performance =
+    // 100); previously the value was dropped and the list de-synced.
+    expected: {
+      timestamp: '2024-01-01T12:00:00.000Z',
+      prio: 7,
+      src: 16,
+      dst: 255,
+      pgn: 130824,
+      description: 'B&G: key-value data',
+      fields: {
+        manufacturerCode: 'B & G',
+        reserved: null,
+        industryCode: 'Marine Industry',
+        list: [
+          { key: 'Target Boat Speed', length: 2, value: 80 },
+          { key: 'Polar Performance', length: 2, value: 100 }
+        ]
+      }
+    },
+    input:
+      '2024-01-01T12:00:00.000Z,7,130824,16,255,10,7d,99,7d,20,50,00,7c,20,64,00',
+    skipEncoderTest: true
   }
 ]


### PR DESCRIPTION
### Problem

PGN 130824 *"B&G: key-value data"* — and any PGN whose **repeating** field set contains a `DYNAMIC_FIELD_KEY` / `DYNAMIC_FIELD_LENGTH` / `DYNAMIC_FIELD_VALUE` triplet — decodes each list entry's `key` and `length` but **drops the `value`**, and de-syncs the rest of the list: every following entry is read starting from the previous entry's value bytes, so it's garbage.

Before:

```jsonc
"list": [
  { "key": "Target Boat Speed", "length": 2 },              // value missing
  { "key": "Average True Wind Direction", "length": 0 },    // the value bytes, misread
  { "key": "Altitude", "length": 0 },                       // garbage
  { "key": "Altitude", "length": 0 }                        // garbage
]
```

### Root cause

When a `DYNAMIC_FIELD_VALUE` is read, its bit length is resolved by `lookupKeyBitLength`, which looks up the sibling `Key`. But `readValue` passed it `pgn.fields` — the **top-level** field accumulator — whereas inside a repeating field set the `key`/`length` live in the **per-repetition `group`** object. So `lookupKeyBitLength` couldn't find the key, returned `undefined`, and `readValue` hit `return [null, undefined]`: the value was dropped **and** the bit cursor wasn't advanced, so the next "key" was read from the value's bytes.

Non-repeating key-value PGNs (e.g. 130845 *"Simnet: Key Value"*) were unaffected — their `key` is a top-level field, so the `pgn.fields` lookup happened to work — which is why this went unnoticed.

### Fix

1. Thread the current repetition's accumulator (`group`) from the repeating-field-set loops through `readField` → `readValue` → `lookupKeyBitLength` via a new optional `data` parameter (defaults to `pgn.fields`, so non-repeating callers are unchanged).
2. Resolve the value's length from the sibling `DYNAMIC_FIELD_LENGTH` field on the wire (`length * 8` bits) rather than the key catalog's nominal `Bits`. The wire length is authoritative: it consumes exactly the bytes present (including length-0 values), keeping the list in sync. The catalog lookup remains as a fallback (e.g. for the encoder, where the length field may not be populated).

After:

```jsonc
"list": [
  { "key": "Target Boat Speed", "length": 2, "value": 80 },
  { "key": "Polar Performance", "length": 2, "value": 100 }
]
```

Values are raw integers, consistent with the existing non-repeating behaviour (130845 decodes `value: 88`). Per-key resolution/unit scaling (the `BANDG_KEY_VALUE` field-type catalog carries `Resolution`/`Unit`) is left to the consumer — happy to follow up with that as a separate change if you'd prefer canboatjs apply it.

### Tests

Adds a B&G 130824 decode case to `test/pgns/130824.js` next to the existing Maretron variant. `npm test` → **193 passing, 0 failing** (was 192).

The decoded values were also validated against a real B&G H5000's own data output (its `ws://…:2053` performance feed): Target Boat Speed, Target TWA, Polar Performance, VMG, leeway etc. all matched once decoded this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for variable-length dynamic fields during message decoding, including repeating key-value data with correctly resolved lengths.
* **Bug Fixes**
  * Fixed value decoding for records that rely on related length fields, so dynamic fields now use the correct bit sizing in more cases.
* **Tests**
  * Added a new decoding fixture for a message with repeating `{ key, length, value }` entries to reduce regression risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->