### PR TITLE
fix: resolve address claim standoff between identical NAMEs

### DIFF
--- a/lib/n2kDevice.test.ts
+++ b/lib/n2kDevice.test.ts
@@ -253,6 +253,7 @@ describe('identical NAME address claims', () => {
     const app = {
       on: () => undefined,
       removeListener: () => undefined,
+      emit: () => undefined,
       setProviderError: jest.fn(),
       setProviderStatus: jest.fn()
     }
@@ -265,14 +266,20 @@ describe('identical NAME address claims', () => {
     expect(dev.address).not.toBe(before)
     expect((dev.addressClaim as any).fields.uniqueNumber).toBe(613748)
     expect(dev.foundConflict).toBe(true)
+    // the error names the value that collided
     expect(app.setProviderError).toHaveBeenCalledWith(
       'test',
-      expect.stringContaining('identical NAME')
+      expect.stringContaining('613748')
     )
-    // the re-claim goes out after the randomized decorrelation delay
+    // claim-silent until the new address has been claimed
+    expect(dev.cansend).toBe(false)
+    // the re-claim goes out after the randomized decorrelation delay,
+    // and cansend returns once the claim-detection window passes
     expect(canbus.sendPGN).not.toHaveBeenCalled()
     jest.advanceTimersByTime(160)
     expect(canbus.sendPGN).toHaveBeenCalled()
+    jest.advanceTimersByTime(5000)
+    expect(dev.cansend).toBe(true)
   })
 
   test('unconfigured uniqueNumber: re-randomizes and persists a new one', () => {
@@ -303,6 +310,9 @@ describe('identical NAME address claims', () => {
     const seen: number[] = []
     for (let i = 0; i < 6; i++) {
       seen.push(dev.address)
+      // each reaction claim-silences the device; model spaced-out
+      // events where the claim has completed in between
+      dev.cansend = true
       dev.n2kMessage(claimForOwnAddress(dev))
     }
 
@@ -339,6 +349,7 @@ describe('identical NAME address claims', () => {
     dev.cansend = true
 
     for (let i = 0; i < 6; i++) {
+      dev.cansend = true
       dev.n2kMessage(claimForOwnAddress(dev))
     }
     expect(dev.identicalClaimReactions).toBe(4)

--- a/lib/n2kDevice.test.ts
+++ b/lib/n2kDevice.test.ts
@@ -207,3 +207,172 @@ describe('N2kDevice address claim options', () => {
     expect(ac.fields.systemInstance).toBe(0)
   })
 })
+
+describe('identical NAME address claims', () => {
+  // Two devices presenting byte-identical 64-bit NAMEs (e.g. a cloned
+  // SignalK config dir on a second machine) can't be separated by ISO
+  // arbitration — the < / > comparison never fires. The device must
+  // yield its address instead of standing off forever.
+  let dev: CanDevice | undefined
+  let errorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    if (dev) {
+      dev.stop()
+      dev = undefined
+    }
+    jest.useRealTimers()
+    errorSpy.mockRestore()
+  })
+
+  // An incoming 60928 whose data bytes encode exactly our own NAME,
+  // claiming whatever address the device currently holds. The claim
+  // comparison encodes only the 8 data bytes, so header differences
+  // (src/dst/prio) don't matter — but src must match our address for
+  // the conflict path to run at all.
+  function claimForOwnAddress(
+    device: CanDevice,
+    fieldOverrides: Record<string, unknown> = {}
+  ) {
+    return {
+      pgn: 60928,
+      dst: 255,
+      src: device.address,
+      prio: 6,
+      fields: { ...(device.addressClaim as any).fields, ...fieldOverrides }
+    } as any
+  }
+
+  test('configured uniqueNumber: yields address, keeps identity, raises error', () => {
+    const canbus = { sendPGN: jest.fn() }
+    const app = {
+      on: () => undefined,
+      removeListener: () => undefined,
+      setProviderError: jest.fn(),
+      setProviderStatus: jest.fn()
+    }
+    dev = new CanDevice(canbus, makeOptions({ app, uniqueNumber: 613748 }))
+    dev.cansend = true
+    const before = dev.address
+
+    dev.n2kMessage(claimForOwnAddress(dev))
+
+    expect(dev.address).not.toBe(before)
+    expect((dev.addressClaim as any).fields.uniqueNumber).toBe(613748)
+    expect(dev.foundConflict).toBe(true)
+    expect(app.setProviderError).toHaveBeenCalledWith(
+      'test',
+      expect.stringContaining('identical NAME')
+    )
+    // the re-claim goes out after the randomized decorrelation delay
+    expect(canbus.sendPGN).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(160)
+    expect(canbus.sendPGN).toHaveBeenCalled()
+  })
+
+  test('unconfigured uniqueNumber: re-randomizes and persists a new one', () => {
+    const { savePersistedData } = jest.requireMock('./persist')
+    savePersistedData.mockClear()
+    const canbus = { sendPGN: jest.fn() }
+    dev = new CanDevice(canbus, makeOptions({ uniqueNumber: undefined }))
+    dev.cansend = true
+    const before = dev.address
+
+    dev.n2kMessage(claimForOwnAddress(dev))
+
+    expect(dev.address).not.toBe(before)
+    // constructor persisted the initial random number, the conflict
+    // reaction persisted the replacement — and the claim now carries it
+    const calls = savePersistedData.mock.calls.filter(
+      (c: unknown[]) => c[2] === 'uniqueNumber'
+    )
+    expect(calls.length).toBe(2)
+    expect((dev.addressClaim as any).fields.uniqueNumber).toBe(calls[1][3])
+  })
+
+  test('reactions are capped so transmit-echo cannot cause endless hopping', () => {
+    const canbus = { sendPGN: jest.fn() }
+    dev = new CanDevice(canbus, makeOptions({ uniqueNumber: 613748 }))
+    dev.cansend = true
+
+    const seen: number[] = []
+    for (let i = 0; i < 6; i++) {
+      seen.push(dev.address)
+      dev.n2kMessage(claimForOwnAddress(dev))
+    }
+
+    // four reactions moved the address, the fifth and sixth were ignored
+    expect(dev.identicalClaimReactions).toBe(4)
+    expect(dev.address).toBe(seen[4])
+    expect(dev.address).toBe(seen[5])
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('giving up'))
+  })
+
+  test('differing NAMEs still resolve via normal arbitration', () => {
+    const canbus = { sendPGN: jest.fn() }
+    dev = new CanDevice(canbus, makeOptions({ uniqueNumber: 12345 }))
+    dev.cansend = true
+    const before = dev.address
+
+    // higher uniqueNumber -> our claim is smaller -> we defend and stay
+    dev.n2kMessage(claimForOwnAddress(dev, { uniqueNumber: 99999 }))
+
+    expect(dev.address).toBe(before)
+    expect(canbus.sendPGN).toHaveBeenCalledTimes(1)
+  })
+
+  test('cap and suppression reset once the time window rolls over', () => {
+    const canbus = { sendPGN: jest.fn() }
+    // advancing past the claim-detection timeout fires the checker,
+    // which emits on the app — the stub needs an emit
+    const app = {
+      on: () => undefined,
+      removeListener: () => undefined,
+      emit: () => undefined
+    }
+    dev = new CanDevice(canbus, makeOptions({ app, uniqueNumber: 613748 }))
+    dev.cansend = true
+
+    for (let i = 0; i < 6; i++) {
+      dev.n2kMessage(claimForOwnAddress(dev))
+    }
+    expect(dev.identicalClaimReactions).toBe(4)
+    expect(dev.identicalClaimSuppressed).toBe(true)
+
+    jest.advanceTimersByTime(61 * 1000)
+
+    const before = dev.address
+    dev.n2kMessage(claimForOwnAddress(dev))
+    // a fresh window reacts (and can report) again
+    expect(dev.address).not.toBe(before)
+    expect(dev.identicalClaimReactions).toBe(1)
+    expect(dev.identicalClaimSuppressed).toBe(false)
+  })
+
+  test('caller-supplied addressClaim without a uniqueNumber still re-randomizes', () => {
+    // The constructor backfills a uniqueNumber into a caller-supplied
+    // claim that carries none — that value came from persistence or a
+    // random draw, not user intent, so conflict handling may replace it.
+    const { savePersistedData } = jest.requireMock('./persist')
+    savePersistedData.mockClear()
+    const canbus = { sendPGN: jest.fn() }
+    dev = new CanDevice(
+      canbus,
+      makeOptions({ addressClaim: {}, uniqueNumber: undefined })
+    )
+    dev.cansend = true
+
+    dev.n2kMessage(claimForOwnAddress(dev))
+
+    const calls = savePersistedData.mock.calls.filter(
+      (c: unknown[]) => c[2] === 'uniqueNumber'
+    )
+    expect(calls.length).toBe(2)
+    expect((dev.addressClaim as any).fields.uniqueNumber).toBe(calls[1][3])
+  })
+})

--- a/lib/n2kDevice.ts
+++ b/lib/n2kDevice.ts
@@ -536,6 +536,9 @@ function handleIdenticalNameClaim(device: N2kDevice) {
 
   const fields = (device.addressClaim.fields = device.addressClaim.fields || {})
   const configured = device.uniqueNumberConfigured
+  // captured before the re-randomization below so the error names the
+  // value that actually collided, not its just-generated replacement
+  const duplicateUniqueNumber = fields.uniqueNumber
   if (!configured) {
     const newUniqueNumber = Math.floor(Math.random() * Math.floor(2097151))
     device.debug(
@@ -550,13 +553,18 @@ function handleIdenticalNameClaim(device: N2kDevice) {
 
   const msg =
     `Another device claimed address ${device.address} with our identical NAME` +
-    ` (uniqueNumber ${fields.uniqueNumber})` +
+    ` (uniqueNumber ${duplicateUniqueNumber})` +
     (configured ? ' — configure distinct uniqueNumbers on each device.' : '.') +
     ' Moving to another address.'
   console.error(msg)
   device.setError(msg)
 
   increaseOwnAddress(device)
+  // Claim-silence until the re-claim's detection window passes:
+  // transmitting from — or accepting unicast for — the new address
+  // before it has been claimed would violate the claim protocol.
+  // sendAddressClaim's checker restores cansend afterwards.
+  device.cansend = false
   if (device.identicalClaimTimer) {
     clearTimeout(device.identicalClaimTimer)
   }

--- a/lib/n2kDevice.ts
+++ b/lib/n2kDevice.ts
@@ -60,6 +60,11 @@ export class N2kDevice extends EventEmitter {
   addressClaimSentAt?: number
   addressClaimChecker?: any
   heartbeatInterval?: any
+  identicalClaimReactions: number
+  identicalClaimWindowStart?: number
+  identicalClaimSuppressed: boolean
+  identicalClaimTimer?: any
+  uniqueNumberConfigured: boolean
   debug: any
 
   constructor(options: any, debugName: string) {
@@ -154,6 +159,17 @@ export class N2kDevice extends EventEmitter {
     // caller-supplied claim's identity instead of silently overwriting it.
     const ac: any = this.addressClaim
     const fields = (ac.fields = ac.fields || {})
+    // A uniqueNumber is "configured" — deliberate user identity that
+    // conflict handling must never re-randomize — when it came from
+    // options.uniqueNumber or was carried on a caller-supplied
+    // addressClaim. A value backfilled below from persistence or a
+    // random draw is ours to regenerate.
+    this.uniqueNumberConfigured =
+      options.uniqueNumber !== undefined ||
+      (options.addressClaim !== undefined &&
+        (fields.uniqueNumber !== undefined ||
+          ac.uniqueNumber !== undefined ||
+          ac['Unique Number'] !== undefined))
     if (fields.uniqueNumber === undefined) {
       const legacy = ac.uniqueNumber ?? ac['Unique Number']
       if (legacy !== undefined) {
@@ -206,6 +222,8 @@ export class N2kDevice extends EventEmitter {
     this.address = address!
     this.cansend = false
     this.foundConflict = false
+    this.identicalClaimReactions = 0
+    this.identicalClaimSuppressed = false
     this.heartbeatCounter = 0
     this.devices = {}
     this.sentAvailable = false
@@ -240,6 +258,10 @@ export class N2kDevice extends EventEmitter {
     if (this.addressClaimChecker) {
       clearTimeout(this.addressClaimChecker)
       this.addressClaimChecker = undefined
+    }
+    if (this.identicalClaimTimer) {
+      clearTimeout(this.identicalClaimTimer)
+      this.identicalClaimTimer = undefined
     }
     this.cansend = false
   }
@@ -444,7 +466,12 @@ function handleISOAddressClaim(device: N2kDevice, n2kMsg: PGN_60928) {
     device.addressClaim
   )
 
-  if (uint64ValueFromOurOwnClaim < uint64ValueFromReceivedClaim) {
+  if (
+    uint64ValueFromOurOwnClaim.toString() ===
+    uint64ValueFromReceivedClaim.toString()
+  ) {
+    handleIdenticalNameClaim(device)
+  } else if (uint64ValueFromOurOwnClaim < uint64ValueFromReceivedClaim) {
     device.debug(
       `Address conflict detected! Kept our address as ${device.address}.`
     )
@@ -457,6 +484,89 @@ function handleISOAddressClaim(device: N2kDevice, n2kMsg: PGN_60928) {
     )
     sendAddressClaim(device)
   }
+}
+
+const IDENTICAL_CLAIM_MAX_REACTIONS = 4
+const IDENTICAL_CLAIM_WINDOW = 60 * 1000
+
+// An incoming claim for OUR address carrying OUR exact 64-bit NAME.
+//
+// ISO 11783-5 arbitration assumes NAMEs are unique, so the < / > branches
+// above can never resolve this: neither side yields, both devices keep
+// transmitting with the same source address, and at the CAN level that
+// means repeated collisions of identical arbitration IDs with different
+// data — error frames that eventually drive a controller error-passive or
+// bus-off. Seen in the field when a SignalK config dir is cloned to a
+// second machine on the same bus (identical configured or persisted
+// uniqueNumber).
+//
+// The tie is unwinnable, so yielding is the only safe move: hop to a free
+// address, after a short random delay so two identical twins that react
+// to each other simultaneously don't hop in lockstep. When our
+// uniqueNumber wasn't explicitly configured, also re-randomize and persist
+// it so the NAMEs differ and every later conflict resolves by normal
+// arbitration; a configured uniqueNumber is user intent, so it is kept
+// and a loud error asks for distinct values instead.
+//
+// Reactions are capped per time window: a transport that echoes our own
+// transmissions back to us is indistinguishable from an identical twin,
+// and hopping forever would be worse than the standoff. After the cap we
+// stay put and surface the error.
+function handleIdenticalNameClaim(device: N2kDevice) {
+  const now = Date.now()
+  if (
+    device.identicalClaimWindowStart === undefined ||
+    now - device.identicalClaimWindowStart > IDENTICAL_CLAIM_WINDOW
+  ) {
+    device.identicalClaimWindowStart = now
+    device.identicalClaimReactions = 0
+    device.identicalClaimSuppressed = false
+  }
+  if (device.identicalClaimReactions >= IDENTICAL_CLAIM_MAX_REACTIONS) {
+    if (!device.identicalClaimSuppressed) {
+      device.identicalClaimSuppressed = true
+      const msg = `Repeated identical address claims for address ${device.address} — giving up conflict resolution (own transmissions echoed back?)`
+      console.error(msg)
+      device.setError(msg)
+    }
+    return
+  }
+  device.identicalClaimReactions++
+  device.foundConflict = true
+
+  const fields = (device.addressClaim.fields = device.addressClaim.fields || {})
+  const configured = device.uniqueNumberConfigured
+  if (!configured) {
+    const newUniqueNumber = Math.floor(Math.random() * Math.floor(2097151))
+    device.debug(
+      `re-randomizing uniqueNumber ${fields.uniqueNumber} -> ${newUniqueNumber}`
+    )
+    fields.uniqueNumber = newUniqueNumber
+    if (device.productInfo?.fields) {
+      device.productInfo.fields.modelSerialCode = newUniqueNumber.toString()
+    }
+    device.savePersistedData('uniqueNumber', newUniqueNumber)
+  }
+
+  const msg =
+    `Another device claimed address ${device.address} with our identical NAME` +
+    ` (uniqueNumber ${fields.uniqueNumber})` +
+    (configured ? ' — configure distinct uniqueNumbers on each device.' : '.') +
+    ' Moving to another address.'
+  console.error(msg)
+  device.setError(msg)
+
+  increaseOwnAddress(device)
+  if (device.identicalClaimTimer) {
+    clearTimeout(device.identicalClaimTimer)
+  }
+  device.identicalClaimTimer = setTimeout(
+    () => {
+      device.identicalClaimTimer = undefined
+      sendAddressClaim(device)
+    },
+    Math.floor(Math.random() * 153)
+  )
 }
 
 function increaseOwnAddress(device: N2kDevice) {


### PR DESCRIPTION
## Problem

`handleISOAddressClaim` only has `<` and `>` branches. When another device claims our address with a byte-identical 64-bit NAME, neither branch fires: neither side yields, and both devices keep transmitting from the same source address. At the CAN level that means repeated collisions of identical arbitration IDs carrying different data — error frames that eventually push a controller error-passive or bus-off.

This isn't hypothetical: I just debugged a boat with two SignalK servers (socketcan) on one backbone after the owner cloned his config dir to the second machine, so both had the same configured `uniqueNumber`. Both silently sat on address 100, and one interface ended up deaf. Changing the uniqueNumber afterwards didn't visibly help because the standoff had already taken the loser off the bus. The identical-NAME case also arises with a cloned `canboatjs-data.json` (persisted uniqueNumber) and with the pre-fields-era all-ones sentinel uniqueNumber that older canboatjs versions emitted.

## Fix

On an identical-NAME claim the device now yields, since the tie is unwinnable by arbitration:

- moves to a free address and re-claims after a short random delay (0–153 ms), so two identical twins that react to each other simultaneously don't hop in lockstep
- raises a provider error naming the uniqueNumber so the user learns about the duplicate identity
- when the uniqueNumber was *not* explicitly configured (backfilled from persistence or a random draw), re-randomizes and persists it, so every later conflict resolves by normal `<`/`>` arbitration; an explicitly configured uniqueNumber is user intent and is kept, with the error asking for distinct values instead
- reactions are capped per 60 s window: a transport that echoes our own transmissions back is indistinguishable from an identical twin, and endless address hopping would be worse than the standoff — after the cap the device stays put and reports once. The cap resets with the window so an ongoing real conflict keeps being reported.

Whether the uniqueNumber counts as configured is decided in the constructor (options.uniqueNumber, or a caller-supplied addressClaim that carried its own uniqueNumber) — a claim object the constructor had to backfill is ours to regenerate.

## Tested

- 6 new jest cases in `lib/n2kDevice.test.ts`: configured identity yields address but keeps uniqueNumber and raises the provider error; unconfigured identity re-randomizes and persists; reaction cap stops echo-driven hopping; cap and suppression reset after the window; caller-supplied claim without uniqueNumber still re-randomizes; differing NAMEs still resolve via the existing arbitration path
- full jest suite passes; `npm run ci-lint` clean; the mocha suite shows the same 4 pre-existing encoder failures as current master (unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resolution for “identical NAME” address-claim collisions to avoid repeated address changes.
  - When conflicts occur, devices now retry claiming a new free address after a short decorrelation delay.
  - Added protection against excessive identical-claim reactions, with clear error reporting when giving up.
  - If the device’s unique identifier wasn’t explicitly set, it’s now re-randomized, persisted, and reflected in the claim.
  - If incoming claims omit the unique identifier, it is now completed and later kept consistent.
  - Conflict suppression automatically resets after the protection window expires.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->